### PR TITLE
Add `archive-get` subcommand

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -246,6 +246,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bumpalo"
+version = "3.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37ccbd214614c6783386c1af30caf03192f17891059cecc394b4fb119e363de3"
+
+[[package]]
 name = "byteorder"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -268,15 +274,19 @@ dependencies = [
  "casper-node",
  "casper-types",
  "clap 3.1.18",
+ "futures",
  "lmdb",
  "lmdb-sys",
  "log",
  "once_cell",
  "rand 0.8.5",
+ "reqwest",
  "serde",
  "simplelog",
  "tempfile",
  "thiserror",
+ "tokio",
+ "zstd",
 ]
 
 [[package]]
@@ -390,7 +400,7 @@ dependencies = [
  "num_cpus",
  "once_cell",
  "openssl",
- "parking_lot",
+ "parking_lot 0.11.2",
  "pem",
  "pin-project",
  "prometheus",
@@ -480,6 +490,9 @@ name = "cc"
 version = "1.0.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
+dependencies = [
+ "jobserver",
+]
 
 [[package]]
 name = "cfg-if"
@@ -557,6 +570,22 @@ name = "convert_case"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
+
+[[package]]
+name = "core-foundation"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "194a7a9e6de53fa55116934067c844d9d749312f75c6f6d0980e8c252f8c2146"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
 name = "cpufeatures"
@@ -863,6 +892,15 @@ dependencies = [
  "rand_core 0.5.1",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9852635589dc9f9ea1b6fe9f05b50ef208c85c834a562f0c6abb1c475736ec2b"
+dependencies = [
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -1313,6 +1351,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+dependencies = [
+ "bytes",
+ "hyper",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+]
+
+[[package]]
 name = "idna"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1342,6 +1393,12 @@ checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
  "cfg-if 1.0.0",
 ]
+
+[[package]]
+name = "ipnet"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879d54834c8c76457ef4293a689b2a8c59b076067ad77b15efafbb05f92a592b"
 
 [[package]]
 name = "itertools"
@@ -1388,6 +1445,24 @@ checksum = "43ae63fcfc45e99ab3d1b29a46782ad679e98436c3169d15a167a1108a724b69"
 dependencies = [
  "jemalloc-sys",
  "libc",
+]
+
+[[package]]
+name = "jobserver"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af25a77299a7f711a01975c35a6a424eb6862092cc2d6c72c4ed6cbc56dfc1fa"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "js-sys"
+version = "0.3.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "671a26f820db17c2a2750743f1dd03bafd15b98c9f30c7c2628c024c05d73397"
+dependencies = [
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1582,6 +1657,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "native-tls"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd7e2f3618557f980e0b17e8856252eee3c97fa12c54dff0ca290fb6266ca4a9"
+dependencies = [
+ "lazy_static",
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
 name = "num"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1759,6 +1852,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "openssl-probe"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1791,7 +1890,17 @@ checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
 dependencies = [
  "instant",
  "lock_api",
- "parking_lot_core",
+ "parking_lot_core 0.8.5",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
+dependencies = [
+ "lock_api",
+ "parking_lot_core 0.9.3",
 ]
 
 [[package]]
@@ -1806,6 +1915,19 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "winapi",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09a279cbf25cb0757810394fbc1e359949b59e348145c643a939a525692e6929"
+dependencies = [
+ "cfg-if 1.0.0",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1952,7 +2074,7 @@ dependencies = [
  "fnv",
  "lazy_static",
  "memchr",
- "parking_lot",
+ "parking_lot 0.11.2",
  "protobuf",
  "thiserror",
 ]
@@ -2165,6 +2287,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "reqwest"
+version = "0.11.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46a1f7aa4f35e5e8b4160449f51afc758f0ce6454315a9fa7d0d113e958c41eb"
+dependencies = [
+ "base64",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-tls",
+ "ipnet",
+ "js-sys",
+ "lazy_static",
+ "log",
+ "mime",
+ "native-tls",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "tokio",
+ "tokio-native-tls",
+ "tokio-util 0.6.10",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "winreg",
+]
+
+[[package]]
 name = "rmp"
 version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2226,6 +2385,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef703b7cb59335eae2eb93ceb664c0eb7ea6bf567079d843e09420219668e072"
 
 [[package]]
+name = "schannel"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88d6731146462ea25d9244b2ed5fd1d716d25c52e4d54aa4fb0f3c4e9854dbe2"
+dependencies = [
+ "lazy_static",
+ "windows-sys",
+]
+
+[[package]]
 name = "schemars"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2261,6 +2430,29 @@ name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "security-framework"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dc14f172faf8a0194a3aded622712b0de276821addc574fa54fc0a1167e10dc"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0160a13a177a45bfb43ce71c01580998474f556ad854dcbca936dd2841a5c556"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "semver"
@@ -2665,7 +2857,9 @@ dependencies = [
  "mio",
  "num_cpus",
  "once_cell",
+ "parking_lot 0.12.1",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "winapi",
@@ -2680,6 +2874,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
+dependencies = [
+ "native-tls",
+ "tokio",
 ]
 
 [[package]]
@@ -3145,6 +3349,72 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
+name = "wasm-bindgen"
+version = "0.2.80"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27370197c907c55e3f1a9fbe26f44e937fe6451368324e009cba39e139dc08ad"
+dependencies = [
+ "cfg-if 1.0.0",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.80"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e04185bfa3a779273da532f5025e33398409573f348985af9a1cbf3774d3f4"
+dependencies = [
+ "bumpalo",
+ "lazy_static",
+ "log",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f741de44b75e14c35df886aff5f1eb73aa114fa5d4d00dcd37b5e01259bf3b2"
+dependencies = [
+ "cfg-if 1.0.0",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.80"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17cae7ff784d7e83a2fe7611cfe766ecf034111b49deb850a3dc7699c08251f5"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.80"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99ec0dc7a4756fffc231aab1b9f2f578d23cd391390ab27f952ae0c9b3ece20b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.80"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d554b7f530dee5964d9a9468d95c1f8b8acae4f282807e7d27d4b03099a46744"
+
+[[package]]
 name = "wasmi"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3166,6 +3436,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea78c597064ba73596099281e2f4cfc019075122a65cdda3205af94f0b264d93"
 dependencies = [
  "parity-wasm",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b17e741662c70c8bd24ac5c5b18de314a2c26c32bf8346ee1e6f53de919c283"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -3249,6 +3529,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
 
 [[package]]
+name = "winreg"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "wyz"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3273,4 +3562,33 @@ dependencies = [
  "quote",
  "syn",
  "synstructure",
+]
+
+[[package]]
+name = "zstd"
+version = "0.11.2+zstd.1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20cc960326ece64f010d2d2107537f26dc589a6573a316bd5b1dba685fa5fde4"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "5.0.2+zstd.1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d2a5585e04f9eea4b2a3d1eca508c4dee9592a89ef6f450c11719da0726f4db"
+dependencies = [
+ "libc",
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.1+zstd.1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fd07cbbc53846d9145dbffdf6dd09a7a0aa52be46741825f5c97bdd4f73f12b"
+dependencies = [
+ "cc",
+ "libc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,12 +18,16 @@ casper-hashing = "1"
 casper-node = "1"
 casper-types = "1"
 clap = { version = "3", features = ["cargo"] }
+futures = "0.3.21"
 lmdb = "0.8.0"
 lmdb-sys = "0.8.0"
 log = "0.4.17"
+reqwest = { version = "0.11.10", features = ["stream"] }
 serde = { version = "1", features = ["derive"] }
 simplelog = "0.12.0"
 thiserror = "1"
+tokio = { version = "1", features = ["full"] }
+zstd = "0.11.2"
 
 [dev-dependencies]
 once_cell = "1"

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,11 +8,12 @@ use std::{fs::OpenOptions, process};
 use clap::{crate_description, crate_version, Arg, Command};
 use log::error;
 
-use subcommands::{check, trie_compact, unsparse};
+use subcommands::{archive_get, check, trie_compact, unsparse};
 
 const LOGGING: &str = "logging";
 
 enum DisplayOrder {
+    ArchiveGet,
     Check,
     TrieCompact,
     Unsparse,
@@ -23,6 +24,7 @@ fn cli() -> Command<'static> {
         .version(crate_version!())
         .about(crate_description!())
         .arg_required_else_help(true)
+        .subcommand(archive_get::command(DisplayOrder::ArchiveGet as usize))
         .subcommand(check::command(DisplayOrder::Check as usize))
         .subcommand(trie_compact::command(DisplayOrder::TrieCompact as usize))
         .subcommand(unsparse::command(DisplayOrder::Unsparse as usize))
@@ -59,6 +61,7 @@ fn main() {
     });
 
     let succeeded = match subcommand_name {
+        archive_get::COMMAND_NAME => archive_get::run(matches),
         check::COMMAND_NAME => check::run(matches),
         trie_compact::COMMAND_NAME => trie_compact::run(matches),
         unsparse::COMMAND_NAME => unsparse::run(matches),

--- a/src/subcommands.rs
+++ b/src/subcommands.rs
@@ -1,3 +1,4 @@
+pub mod archive_get;
 pub mod check;
 pub mod trie_compact;
 pub mod unsparse;

--- a/src/subcommands/archive_get.rs
+++ b/src/subcommands/archive_get.rs
@@ -1,0 +1,99 @@
+mod download_stream;
+mod zstd_decode;
+
+use std::io::Error as IoError;
+
+use clap::{Arg, ArgMatches, Command};
+use log::error;
+use reqwest::Error as ReqwestError;
+use thiserror::Error as ThisError;
+
+pub const COMMAND_NAME: &str = "archive-get";
+const URL: &str = "url";
+const OUTPUT: &str = "output";
+const EXTRACT: &str = "extract";
+const WINDOW_LOG_DISTANCE: &str = "window-log-distance";
+
+#[derive(Debug, ThisError)]
+pub enum Error {
+    #[error("HTTP request error: {0}")]
+    Request(#[from] ReqwestError),
+    #[error("Error streaming from zstd decoder to destination file: {0}")]
+    Streaming(IoError),
+    #[error("Error creating destination archive file: {0}")]
+    Destination(IoError),
+    #[error("Error creating tokio runtime: {0}")]
+    Runtime(IoError),
+    #[error("Error setting up zstd decoder: {0}")]
+    ZstdDecoderSetup(IoError),
+}
+
+enum DisplayOrder {
+    Url,
+    Output,
+    Extract,
+    WindowLogDistance,
+}
+
+pub fn command(display_order: usize) -> Command<'static> {
+    Command::new(COMMAND_NAME)
+        .display_order(display_order)
+        .about("Downloads and decompresses a ZSTD TAR archive of a casper-node storage instance.")
+        .arg(
+            Arg::new(URL)
+                .display_order(DisplayOrder::Url as usize)
+                .required(true)
+                .short('u')
+                .long(URL)
+                .takes_value(true)
+                .value_name("URL")
+                .help("URL of the compressed archive."),
+        )
+        .arg(
+            Arg::new(OUTPUT)
+                .display_order(DisplayOrder::Output as usize)
+                .required(true)
+                .short('o')
+                .long(OUTPUT)
+                .takes_value(true)
+                .value_name("OUT_DIR")
+                .help("Output file path for the decompressed TAR archive."),
+        )
+        .arg(
+            Arg::new(EXTRACT)
+                .display_order(DisplayOrder::Extract as usize)
+                .short('x')
+                .long(EXTRACT)
+                .help("Stream the downloaded data into a zstd decoder to output the extracted archive."),
+        )
+        .arg(
+            Arg::new(WINDOW_LOG_DISTANCE)
+                .display_order(DisplayOrder::WindowLogDistance as usize)
+                .required(true)
+                .short('w')
+                .long(WINDOW_LOG_DISTANCE)
+                .takes_value(true)
+                .value_name("WINDOW_LOG_DISTANCE")
+                .help("Window log size passed to the zstd decoder as the \"--long\" parameter."),
+        )
+}
+
+pub fn run(matches: &ArgMatches) -> bool {
+    let url = matches.value_of(URL).unwrap();
+    let dest = matches.value_of(OUTPUT).unwrap();
+    let zstd_decode = matches.is_present(EXTRACT);
+    let log_distance = matches
+        .value_of(WINDOW_LOG_DISTANCE)
+        .map(|log_distance_str| {
+            log_distance_str
+                .parse()
+                .expect("Window log distance must be an integer.")
+        });
+    let result = download_stream::download_archive(url, dest.into(), zstd_decode, log_distance);
+
+    if let Err(error) = &result {
+        error!("Archive get failed. {}", error);
+    }
+
+    result.is_ok()
+}

--- a/src/subcommands/archive_get.rs
+++ b/src/subcommands/archive_get.rs
@@ -1,4 +1,6 @@
 mod download_stream;
+#[cfg(test)]
+mod tests;
 mod zstd_decode;
 
 use std::io::Error as IoError;

--- a/src/subcommands/archive_get/download_stream.rs
+++ b/src/subcommands/archive_get/download_stream.rs
@@ -1,0 +1,103 @@
+use std::{
+    fs::OpenOptions,
+    io::{self as std_io, Read},
+    path::PathBuf,
+    result::Result,
+};
+
+use futures::{io, AsyncRead, AsyncReadExt, TryStreamExt};
+use log::info;
+use tokio::runtime::{Builder as TokioRuntimeBuilder, Runtime};
+
+use super::zstd_decode;
+use super::Error;
+
+pub struct StreamPipe {
+    runtime: Runtime,
+    reader: Box<dyn AsyncRead + Unpin>,
+    pub stream_length: Option<usize>,
+    pub total_bytes_read: usize,
+    pub progress: u64,
+}
+
+impl StreamPipe {
+    fn new(runtime: Runtime, url: &str) -> Result<Self, Error> {
+        let response_future = async {
+            let response_fut = reqwest::get(url).await;
+            match response_fut {
+                Ok(response) => {
+                    let maybe_len = response.content_length().map(|len| {
+                        info!("Download size: {} bytes.", len);
+                        // Highly unlikely scenario where we can't convert `u64` to `usize`.
+                        // This would mean we're running on a 32-bit or older system and the
+                        // content length cannot be represented in that system's pointer size.
+                        len.try_into()
+                            .expect("Couldn't convert content length from u64 to usize")
+                    });
+                    Ok((
+                        response.bytes_stream().map_err(|reqwest_err| {
+                            io::Error::new(io::ErrorKind::Other, reqwest_err)
+                        }),
+                        maybe_len,
+                    ))
+                }
+                Err(request_err) => Err(Error::Request(request_err)),
+            }
+        };
+        let (http_stream, maybe_content_length) = runtime.block_on(response_future)?;
+        let http_stream = http_stream.into_async_read();
+        let reader = Box::new(http_stream) as Box<dyn AsyncRead + Unpin>;
+        Ok(Self {
+            runtime,
+            reader,
+            stream_length: maybe_content_length,
+            total_bytes_read: 0,
+            progress: 1,
+        })
+    }
+}
+
+impl Read for StreamPipe {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        let fut = async { self.reader.read(buf).await };
+        let bytes_read = self.runtime.block_on(fut)?;
+        self.total_bytes_read += bytes_read;
+        if let Some(stream_len) = self.stream_length {
+            while self.total_bytes_read > (stream_len * self.progress as usize) / 20 {
+                info!("Download {}% complete...", self.progress * 5);
+                self.progress += 1;
+            }
+        }
+        Ok(bytes_read)
+    }
+}
+
+pub fn download_archive(
+    url: &str,
+    dest: PathBuf,
+    zstd_decode: bool,
+    log_distance: Option<u32>,
+) -> Result<(), Error> {
+    let mut output_file = OpenOptions::new()
+        .create_new(true)
+        .write(true)
+        .open(dest)
+        .map_err(Error::Destination)?;
+    let runtime = TokioRuntimeBuilder::new_current_thread()
+        .enable_time()
+        .enable_io()
+        .build()
+        .map_err(Error::Runtime)?;
+    let mut stream_pipe = StreamPipe::new(runtime, url)?;
+    let decoded_bytes = if zstd_decode {
+        let mut decoder = zstd_decode::zstd_decode_stream(stream_pipe, log_distance)?;
+        std_io::copy(&mut decoder, &mut output_file).map_err(Error::Streaming)?
+    } else {
+        std_io::copy(&mut stream_pipe, &mut output_file).map_err(Error::Streaming)?
+    };
+    info!("Dowload complete.");
+    if zstd_decode {
+        info!("Decoded {} bytes.", decoded_bytes);
+    }
+    Ok(())
+}

--- a/src/subcommands/archive_get/tests.rs
+++ b/src/subcommands/archive_get/tests.rs
@@ -1,0 +1,184 @@
+use std::{
+    fs::OpenOptions,
+    io::{Read, Write},
+    net::TcpListener,
+    sync::{Arc, Barrier},
+    thread,
+};
+
+use rand::{self, RngCore};
+use zstd::Encoder;
+
+use super::{download_stream::download_archive, zstd_decode::zstd_decode_stream};
+
+const TEST_ADDR_DECODE: &str = "127.0.0.1:9876";
+const TEST_ADDR_NO_DECODE: &str = "127.0.0.1:9875";
+
+fn serve_request(payload: Vec<u8>, barrier: Arc<Barrier>, addr: &str) {
+    let listener = TcpListener::bind(addr).unwrap();
+    {
+        // Accept the connection we're making.
+        let (mut stream, _) = listener.accept().unwrap();
+        let mut buf = vec![];
+        // Don't care about the request contents.
+        stream.read(&mut buf).unwrap();
+        // Write the mock file contents back with a simple HTTP response.
+        stream
+            .write_all(
+                format!(
+                    "HTTP/1.1 200 OK\r\nContent-Length: {}\r\n\r\n",
+                    payload.len()
+                )
+                .as_bytes(),
+            )
+            .unwrap();
+        stream.write_all(&payload).unwrap();
+        // Have a barrier here so we don't drop the stream until we finish
+        // reading on the other end.
+        let _ = barrier.wait();
+    }
+}
+
+#[test]
+fn zstd_decode_roundtrip() {
+    let mut rng = rand::thread_rng();
+    // Generate a random payload.
+    let mut payload = [0u8; 100];
+    rng.fill_bytes(&mut payload);
+
+    // Encode the payload with zstd.
+    let mut encoder = Encoder::new(vec![], 0).unwrap();
+    encoder.write_all(&mut payload).unwrap();
+    let encoded = encoder.finish().unwrap();
+
+    // Decode the response with our function.
+    let mut decoder = zstd_decode_stream(encoded.as_slice(), None).unwrap();
+    let mut decoded = vec![];
+    decoder.read_to_end(&mut decoded).unwrap();
+
+    // Check that the output is the same as the payload.
+    assert_eq!(payload.to_vec(), decoded);
+}
+
+#[test]
+fn archive_get_no_decode() {
+    let mut rng = rand::thread_rng();
+    // Generate a random payload.
+    let mut payload = [0u8; 100];
+    rng.fill_bytes(&mut payload);
+    let payload_copy = payload.to_vec();
+
+    let barrier = Arc::new(Barrier::new(2));
+    let server_barrier = barrier.clone();
+
+    // Set up a server on another thread which will be our
+    // `get` target.
+    let join_handle = thread::spawn(move || {
+        serve_request(payload_copy, server_barrier, TEST_ADDR_NO_DECODE);
+    });
+
+    // Create the directory where we save the downloaded file.
+    let temp_dir = tempfile::tempdir().unwrap();
+    let dest_path = temp_dir.path().join("file.bin");
+
+    // Reqwest needs the schema to be present in the URL.
+    let mut http_addr = "http://".to_string();
+    http_addr.push_str(TEST_ADDR_NO_DECODE);
+
+    // Download the file without zstd encoding.
+    download_archive(&http_addr, dest_path.clone(), false, None)
+        .expect("Error downloading payload");
+
+    // Check that the downloaded contents are the same as our payload.
+    let mut dest_file = OpenOptions::new()
+        .read(true)
+        .open(dest_path.as_path())
+        .expect("Couldn't open destination file");
+    let mut output_bytes = vec![];
+    dest_file
+        .read_to_end(&mut output_bytes)
+        .expect("Couldn't read from destination file");
+    assert_eq!(payload.to_vec(), output_bytes);
+
+    // Let the server thread finish execution.
+    let _ = barrier.wait();
+    join_handle.join().unwrap();
+}
+
+#[test]
+fn archive_get_with_decode() {
+    let mut rng = rand::thread_rng();
+    // Generate a random payload.
+    let mut payload = [0u8; 100];
+    rng.fill_bytes(&mut payload);
+
+    // Encode the payload with zstd.
+    let mut encoder = Encoder::new(vec![], 0).unwrap();
+    encoder.write_all(&mut payload).unwrap();
+    let encoded = encoder.finish().unwrap();
+    let encoded_copy = encoded.clone();
+
+    let barrier = Arc::new(Barrier::new(2));
+    let server_barrier = barrier.clone();
+
+    // Set up a server on another thread which will be our
+    // `get` target.
+    let join_handle = thread::spawn(move || {
+        serve_request(encoded_copy, server_barrier, TEST_ADDR_DECODE);
+    });
+
+    // Create the directory where we save the downloaded file.
+    let temp_dir = tempfile::tempdir().unwrap();
+    let dest_path = temp_dir.path().join("file.bin");
+
+    // Reqwest needs the schema to be present in the URL.
+    let mut http_addr = "http://".to_string();
+    http_addr.push_str(TEST_ADDR_DECODE);
+
+    // Download the file without zstd encoding.
+    download_archive(&http_addr, dest_path.clone(), true, None)
+        .expect("Error downloading and decoding payload");
+
+    // Check that the downloaded contents are the same as our payload.
+    let mut dest_file = OpenOptions::new()
+        .read(true)
+        .open(dest_path.as_path())
+        .expect("Couldn't open destination file");
+    let mut output_bytes = vec![];
+    dest_file
+        .read_to_end(&mut output_bytes)
+        .expect("Couldn't read from destination file");
+    assert_eq!(payload.to_vec(), output_bytes);
+
+    // Let the server thread finish execution.
+    let _ = barrier.wait();
+    join_handle.join().unwrap();
+}
+
+#[test]
+fn archive_get_invalid_url() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let dest_path = temp_dir.path().join("file.bin");
+
+    // No HTTP schema.
+    assert!(download_archive("localhost:10000", dest_path.clone(), false, None).is_err());
+    // No server running at `localhost:10000`.
+    assert!(download_archive("http://localhost:10000", dest_path, false, None).is_err());
+}
+
+#[test]
+fn archive_get_existing_destination() {
+    // Create the directory where we save the downloaded file.
+    let temp_dir = tempfile::tempdir().unwrap();
+    let dest_path = temp_dir.path().join("file.bin");
+
+    // Create the destination file before downloading.
+    let _ = OpenOptions::new()
+        .create_new(true)
+        .write(true)
+        .open(&dest_path)
+        .unwrap();
+    // Download should fail because the file is already present. Address doesn't
+    // matter because the file check is performed first.
+    assert!(download_archive("bogus_address", dest_path, false, None).is_err());
+}

--- a/src/subcommands/archive_get/zstd_decode.rs
+++ b/src/subcommands/archive_get/zstd_decode.rs
@@ -1,0 +1,23 @@
+use std::{
+    io::{BufReader, Read},
+    result::Result,
+};
+
+use log::info;
+use zstd::Decoder;
+
+use super::Error;
+
+pub fn zstd_decode_stream<'a, R: Read>(
+    stream: R,
+    log_distance: Option<u32>,
+) -> Result<Decoder<'a, BufReader<R>>, Error> {
+    let mut decoder = Decoder::new(stream).map_err(Error::ZstdDecoderSetup)?;
+    if let Some(window_log_distance) = log_distance {
+        decoder
+            .window_log_max(window_log_distance)
+            .map_err(Error::ZstdDecoderSetup)?;
+        info!("Set zstd window log size to {}", window_log_distance);
+    }
+    Ok(decoder)
+}


### PR DESCRIPTION
Fixes #8 

Added a new `archive-get` subcommand which downloads an archive from a given URL and optionally decompresses it with `zstd`. The download content is streamed into the `zstd` decoder for efficiency. Users can also choose the `zstd` window log size parameter used by the decoder, equivalent to specifying `--long=$VALUE` for the `unzstd` util.

Added @sacherjj as a reviewer for the CLI API and real-world test scenario purposes only.