### PR TITLE
Clean up technical debt

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -1,2 +1,3 @@
 pub mod db;
 pub mod lmdb_utils;
+pub mod progress;

--- a/src/common.rs
+++ b/src/common.rs
@@ -1,1 +1,2 @@
 pub mod db;
+pub mod lmdb_utils;

--- a/src/common/db.rs
+++ b/src/common/db.rs
@@ -39,6 +39,7 @@ use thiserror::Error;
 
 use casper_types::bytesrepr::Error as BytesreprError;
 
+pub const STORAGE_FILE_NAME: &str = "storage.lmdb";
 const ENTRY_LOG_INTERVAL: usize = 100_000;
 const MAX_DB_READERS: u32 = 100;
 

--- a/src/common/db/tests.rs
+++ b/src/common/db/tests.rs
@@ -141,7 +141,7 @@ fn sanity_check_ser_deser() {
 
 #[test]
 fn good_db_should_pass_check() {
-    let fixture = LmdbTestFixture::new(Some(MockDb::db_name()));
+    let fixture = LmdbTestFixture::new(Some(MockDb::db_name()), None);
     populate_db(&fixture.env, &fixture.db);
 
     assert!(MockDb::check_db(&fixture.env, true, 0).is_ok());
@@ -152,7 +152,7 @@ fn good_db_should_pass_check() {
 
 #[test]
 fn bad_db_should_fail_check() {
-    let fixture = LmdbTestFixture::new(Some(MockDb::db_name()));
+    let fixture = LmdbTestFixture::new(Some(MockDb::db_name()), None);
     populate_faulty_db(&fixture.env, &fixture.db);
 
     assert!(MockDb::check_db(&fixture.env, true, 0).is_err());

--- a/src/common/db/tests.rs
+++ b/src/common/db/tests.rs
@@ -17,9 +17,9 @@ fn gen_faulty_bytes(rng: &mut ThreadRng) -> Vec<u8> {
 
 fn populate_db(env: &Environment, db: &LmdbDatabase) {
     let mut rng = rand::thread_rng();
-    let entries_count = rng.gen_range(10u32..100u32);
+    let entry_count = rng.gen_range(10u32..100u32);
     let mut rw_tx = env.begin_rw_txn().expect("couldn't begin rw transaction");
-    for i in 0..entries_count {
+    for i in 0..entry_count {
         let bytes = gen_bytes(&mut rng);
         let key: [u8; 4] = i.to_le_bytes();
         rw_tx.put(*db, &key, &bytes, WriteFlags::empty()).unwrap();
@@ -29,9 +29,9 @@ fn populate_db(env: &Environment, db: &LmdbDatabase) {
 
 fn populate_faulty_db(env: &Environment, db: &LmdbDatabase) {
     let mut rng = rand::thread_rng();
-    let entries_count = rng.gen_range(10u32..100u32);
+    let entry_count = rng.gen_range(10u32..100u32);
     let mut rw_tx = env.begin_rw_txn().expect("couldn't begin rw transaction");
-    for i in 0..entries_count {
+    for i in 0..entry_count {
         let bytes = if i % 5 == 0 {
             gen_faulty_bytes(&mut rng)
         } else {

--- a/src/common/lmdb_utils.rs
+++ b/src/common/lmdb_utils.rs
@@ -5,7 +5,10 @@ use lmdb_sys::{mdb_stat, MDB_stat};
 
 /// Retrieves the number of entries in a database.
 #[allow(unused)]
-pub fn entries_count<'txn, T: Transaction>(txn: &'txn T, database: Database) -> Result<usize, Error> {
+pub fn entries_count<'txn, T: Transaction>(
+    txn: &'txn T,
+    database: Database,
+) -> Result<usize, Error> {
     unsafe {
         let mut stat = MDB_stat {
             ms_psize: 0,

--- a/src/common/lmdb_utils.rs
+++ b/src/common/lmdb_utils.rs
@@ -1,0 +1,82 @@
+use std::result::Result;
+
+use lmdb::{Database, Error, Transaction};
+use lmdb_sys::{mdb_stat, MDB_stat};
+
+/// Retrieves the number of entries in a database.
+#[allow(unused)]
+pub fn entries_count<'txn, T: Transaction>(txn: &'txn T, database: Database) -> Result<usize, Error> {
+    unsafe {
+        let mut stat = MDB_stat {
+            ms_psize: 0,
+            ms_depth: 0,
+            ms_branch_pages: 0,
+            ms_leaf_pages: 0,
+            ms_overflow_pages: 0,
+            ms_entries: 0,
+        };
+        let result = mdb_stat(txn.txn(), database.dbi(), &mut stat as *mut MDB_stat);
+        if result != 0 {
+            Err(Error::from_err_code(result))
+        } else {
+            Ok(stat.ms_entries)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use lmdb::{Transaction, WriteFlags};
+
+    use crate::test_utils::LmdbTestFixture;
+
+    use super::entries_count;
+
+    #[test]
+    fn db_entries_count() {
+        let fixture = LmdbTestFixture::new(None, None);
+        let env = &fixture.env;
+        let db = fixture.db;
+
+        if let Ok(mut txn) = env.begin_ro_txn() {
+            assert_eq!(entries_count(&mut txn, db).unwrap(), 0);
+            txn.commit().unwrap();
+        }
+
+        let first_dummy_input = [0u8, 1u8];
+        let second_dummy_input = [1u8, 2u8];
+        // Insert the first entry into the database.
+        if let Ok(mut txn) = env.begin_rw_txn() {
+            txn.put(
+                fixture.db,
+                &first_dummy_input,
+                &first_dummy_input,
+                WriteFlags::empty(),
+            )
+            .unwrap();
+            txn.commit().unwrap();
+        };
+
+        if let Ok(mut txn) = env.begin_ro_txn() {
+            assert_eq!(entries_count(&mut txn, db).unwrap(), 1);
+            txn.commit().unwrap();
+        }
+
+        // Insert the second entry into the database.
+        if let Ok(mut txn) = env.begin_rw_txn() {
+            txn.put(
+                fixture.db,
+                &second_dummy_input,
+                &second_dummy_input,
+                WriteFlags::empty(),
+            )
+            .unwrap();
+            txn.commit().unwrap();
+        };
+
+        if let Ok(mut txn) = env.begin_ro_txn() {
+            assert_eq!(entries_count(&mut txn, db).unwrap(), 2);
+            txn.commit().unwrap();
+        };
+    }
+}

--- a/src/common/lmdb_utils.rs
+++ b/src/common/lmdb_utils.rs
@@ -5,21 +5,19 @@ use lmdb_sys::{mdb_stat, MDB_stat};
 
 /// Retrieves the number of entries in a database.
 pub fn entry_count<T: Transaction>(txn: &'_ T, database: Database) -> Result<usize, Error> {
-    unsafe {
-        let mut stat = MDB_stat {
-            ms_psize: 0,
-            ms_depth: 0,
-            ms_branch_pages: 0,
-            ms_leaf_pages: 0,
-            ms_overflow_pages: 0,
-            ms_entries: 0,
-        };
-        let result = mdb_stat(txn.txn(), database.dbi(), &mut stat as *mut MDB_stat);
-        if result != 0 {
-            Err(Error::from_err_code(result))
-        } else {
-            Ok(stat.ms_entries)
-        }
+    let mut stat = MDB_stat {
+        ms_psize: 0,
+        ms_depth: 0,
+        ms_branch_pages: 0,
+        ms_leaf_pages: 0,
+        ms_overflow_pages: 0,
+        ms_entries: 0,
+    };
+    let result = unsafe { mdb_stat(txn.txn(), database.dbi(), &mut stat as *mut MDB_stat) };
+    if result != 0 {
+        Err(Error::from_err_code(result))
+    } else {
+        Ok(stat.ms_entries)
     }
 }
 

--- a/src/common/lmdb_utils.rs
+++ b/src/common/lmdb_utils.rs
@@ -4,7 +4,6 @@ use lmdb::{Database, Error, Transaction};
 use lmdb_sys::{mdb_stat, MDB_stat};
 
 /// Retrieves the number of entries in a database.
-#[allow(unused)]
 pub fn entry_count<T: Transaction>(txn: &'_ T, database: Database) -> Result<usize, Error> {
     unsafe {
         let mut stat = MDB_stat {
@@ -76,6 +75,17 @@ mod tests {
 
         if let Ok(txn) = env.begin_ro_txn() {
             assert_eq!(entry_count(&txn, db).unwrap(), 2);
+            txn.commit().unwrap();
+        };
+
+        // Delete the first entry from the database.
+        if let Ok(mut txn) = env.begin_rw_txn() {
+            txn.del(fixture.db, &first_dummy_input, None).unwrap();
+            txn.commit().unwrap();
+        };
+
+        if let Ok(txn) = env.begin_ro_txn() {
+            assert_eq!(entry_count(&txn, db).unwrap(), 1);
             txn.commit().unwrap();
         };
     }

--- a/src/common/lmdb_utils.rs
+++ b/src/common/lmdb_utils.rs
@@ -5,10 +5,7 @@ use lmdb_sys::{mdb_stat, MDB_stat};
 
 /// Retrieves the number of entries in a database.
 #[allow(unused)]
-pub fn entries_count<'txn, T: Transaction>(
-    txn: &'txn T,
-    database: Database,
-) -> Result<usize, Error> {
+pub fn entry_count<T: Transaction>(txn: &'_ T, database: Database) -> Result<usize, Error> {
     unsafe {
         let mut stat = MDB_stat {
             ms_psize: 0,
@@ -33,16 +30,16 @@ mod tests {
 
     use crate::test_utils::LmdbTestFixture;
 
-    use super::entries_count;
+    use super::entry_count;
 
     #[test]
-    fn db_entries_count() {
+    fn db_entry_count() {
         let fixture = LmdbTestFixture::new(None, None);
         let env = &fixture.env;
         let db = fixture.db;
 
-        if let Ok(mut txn) = env.begin_ro_txn() {
-            assert_eq!(entries_count(&mut txn, db).unwrap(), 0);
+        if let Ok(txn) = env.begin_ro_txn() {
+            assert_eq!(entry_count(&txn, db).unwrap(), 0);
             txn.commit().unwrap();
         }
 
@@ -60,8 +57,8 @@ mod tests {
             txn.commit().unwrap();
         };
 
-        if let Ok(mut txn) = env.begin_ro_txn() {
-            assert_eq!(entries_count(&mut txn, db).unwrap(), 1);
+        if let Ok(txn) = env.begin_ro_txn() {
+            assert_eq!(entry_count(&txn, db).unwrap(), 1);
             txn.commit().unwrap();
         }
 
@@ -77,8 +74,8 @@ mod tests {
             txn.commit().unwrap();
         };
 
-        if let Ok(mut txn) = env.begin_ro_txn() {
-            assert_eq!(entries_count(&mut txn, db).unwrap(), 2);
+        if let Ok(txn) = env.begin_ro_txn() {
+            assert_eq!(entry_count(&txn, db).unwrap(), 2);
             txn.commit().unwrap();
         };
     }

--- a/src/common/progress.rs
+++ b/src/common/progress.rs
@@ -1,3 +1,6 @@
+const STEPS: usize = 20;
+const PROGRESS_MULTIPLIER: u64 = 100 / STEPS as u64;
+
 pub struct ProgressTracker {
     total_to_process: usize,
     processed: usize,
@@ -15,8 +18,8 @@ impl ProgressTracker {
 
     pub fn advance<F: Fn(u64)>(&mut self, step: usize, log_progress: F) {
         self.processed += step;
-        while self.processed > (self.total_to_process * self.progress_factor as usize) / 20 {
-            log_progress(self.progress_factor * 5);
+        while self.processed > (self.total_to_process * self.progress_factor as usize) / STEPS {
+            log_progress(self.progress_factor * PROGRESS_MULTIPLIER);
             self.progress_factor += 1;
         }
     }

--- a/src/common/progress.rs
+++ b/src/common/progress.rs
@@ -1,0 +1,27 @@
+pub struct ProgressTracker {
+    total_to_process: usize,
+    processed: usize,
+    progress_factor: u64,
+}
+
+impl ProgressTracker {
+    pub fn new(total_to_process: usize) -> Self {
+        Self {
+            total_to_process,
+            processed: 0,
+            progress_factor: 1,
+        }
+    }
+
+    pub fn advance<F: Fn(u64)>(&mut self, step: usize, log_progress: F) {
+        self.processed += step;
+        while self.processed > (self.total_to_process * self.progress_factor as usize) / 20 {
+            log_progress(self.progress_factor * 5);
+            self.progress_factor += 1;
+        }
+    }
+
+    pub fn finish<F: Fn()>(self, log_completion: F) {
+        log_completion()
+    }
+}

--- a/src/common/progress.rs
+++ b/src/common/progress.rs
@@ -1,30 +1,71 @@
-const STEPS: usize = 20;
-const PROGRESS_MULTIPLIER: u64 = 100 / STEPS as u64;
+use std::result::Result;
 
+use log::warn;
+
+// The tracker will log 20 times during its operation.
+const STEPS: usize = 20;
+// The tracker will log progress every in 5% completion intervals.
+const PROGRESS_MULTIPLIER: u64 = 100 / STEPS as u64;
+// Error message for initialization of a progress tracker with nothing
+// to process.
+const NULL_TOTAL_TO_PROCESS_ERROR: &str = "Cannot initialize total to process with 0";
+
+/// Tracks and logs progress of an operation in a human readable form.
+/// Whenever (1 / number of steps) of the total amount has been processed,
+/// this structure calls the `log_progress` function, which takes the
+/// percentage completed so far as a parameter.
 pub struct ProgressTracker {
+    /// Total amount there is to process.
     total_to_process: usize,
+    /// Amount processed so far.
     processed: usize,
+    /// Internal counter to keep track of the number of steps completed
+    /// so far relative to the maximum amount of steps this operation
+    /// will do, defined in `STEPS`.
     progress_factor: u64,
+    /// Function which takes the completion rate as a percentage as
+    /// input. It is called zero or more times as progress is being made
+    /// using `ProgressTracker::advance_by`. The purpose of this function
+    /// is to allow users to create custom log messages for their specific
+    /// operation.
+    log_progress: Box<dyn Fn(u64)>,
 }
 
 impl ProgressTracker {
-    pub fn new(total_to_process: usize) -> Self {
-        Self {
-            total_to_process,
-            processed: 0,
-            progress_factor: 1,
+    /// Create a new progress tracker by initializing it with a non-zero
+    /// amount to be processed and a log function.
+    pub fn new(
+        total_to_process: usize,
+        log_progress: Box<dyn Fn(u64)>,
+    ) -> Result<Self, &'static str> {
+        if total_to_process == 0 {
+            Err(NULL_TOTAL_TO_PROCESS_ERROR)
+        } else {
+            Ok(Self {
+                total_to_process,
+                processed: 0,
+                progress_factor: 1,
+                log_progress,
+            })
         }
     }
 
-    pub fn advance<F: Fn(u64)>(&mut self, step: usize, log_progress: F) {
+    /// Advance the progress tracker by a specific amount. If it passes
+    /// a milestone ((1 / STEP) of the total amount to process),
+    /// `log_progress` will be called with the current completion rate
+    /// as input.
+    pub fn advance_by(&mut self, step: usize) {
         self.processed += step;
-        while self.processed > (self.total_to_process * self.progress_factor as usize) / STEPS {
-            log_progress(self.progress_factor * PROGRESS_MULTIPLIER);
+        while self.processed >= (self.total_to_process * self.progress_factor as usize) / STEPS {
+            (*self.log_progress)(self.progress_factor * PROGRESS_MULTIPLIER);
             self.progress_factor += 1;
         }
-    }
-
-    pub fn finish<F: Fn()>(self, log_completion: F) {
-        log_completion()
+        if self.processed > self.total_to_process {
+            warn!(
+                "Exceeded total amount to process {} by {}",
+                self.total_to_process,
+                self.processed - self.total_to_process
+            );
+        }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -71,7 +71,9 @@ fn main() {
     let result: Result<(), Error> = match subcommand_name {
         archive::COMMAND_NAME => archive::run(matches).map_err(Error::from),
         check::COMMAND_NAME => check::run(matches).map_err(Error::from),
-        latest_block_summary::COMMAND_NAME => latest_block_summary::run(matches).map_err(Error::from),
+        latest_block_summary::COMMAND_NAME => {
+            latest_block_summary::run(matches).map_err(Error::from)
+        }
         trie_compact::COMMAND_NAME => trie_compact::run(matches).map_err(Error::from),
         unsparse::COMMAND_NAME => unsparse::run(matches).map_err(Error::from),
         _ => unreachable!("{} should be handled above", subcommand_name),

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,7 @@ use std::{fs::OpenOptions, process};
 use clap::{crate_description, crate_version, Arg, Command};
 use log::error;
 
-use subcommands::{archive, check, latest_block_summary, trie_compact, unsparse};
+use subcommands::{archive, check, latest_block_summary, trie_compact, unsparse, Error};
 
 const LOGGING: &str = "logging";
 
@@ -61,20 +61,24 @@ fn main() {
     );
 
     let (subcommand_name, matches) = arg_matches.subcommand().unwrap_or_else(|| {
-        error!("{}", cli().get_long_about().unwrap());
+        error!(
+            "{}",
+            cli().get_long_about().expect("should have long about")
+        );
         process::exit(1);
     });
 
-    let succeeded = match subcommand_name {
-        archive::COMMAND_NAME => archive::run(matches),
-        check::COMMAND_NAME => check::run(matches),
-        latest_block_summary::COMMAND_NAME => latest_block_summary::run(matches),
-        trie_compact::COMMAND_NAME => trie_compact::run(matches),
-        unsparse::COMMAND_NAME => unsparse::run(matches),
+    let result: Result<(), Error> = match subcommand_name {
+        archive::COMMAND_NAME => archive::run(matches).map_err(Error::from),
+        check::COMMAND_NAME => check::run(matches).map_err(Error::from),
+        latest_block_summary::COMMAND_NAME => latest_block_summary::run(matches).map_err(Error::from),
+        trie_compact::COMMAND_NAME => trie_compact::run(matches).map_err(Error::from),
+        unsparse::COMMAND_NAME => unsparse::run(matches).map_err(Error::from),
         _ => unreachable!("{} should be handled above", subcommand_name),
     };
 
-    if !succeeded {
+    if let Err(run_err) = result {
+        error!("{}", run_err);
         process::exit(1);
     }
 }

--- a/src/subcommands.rs
+++ b/src/subcommands.rs
@@ -3,3 +3,27 @@ pub mod check;
 pub mod latest_block_summary;
 pub mod trie_compact;
 pub mod unsparse;
+
+use thiserror::Error as ThisError;
+
+use archive::{CreateError, UnpackError};
+use check::Error as CheckError;
+use latest_block_summary::Error as LatestBlockSummaryError;
+use trie_compact::Error as TrieCompactError;
+use unsparse::Error as UnsparseError;
+
+#[derive(ThisError, Debug)]
+pub enum Error {
+    #[error("Archive create failed: {0}")]
+    ArchiveCreate(#[from] CreateError),
+    #[error("Archive unpack failed: {0}")]
+    ArchiveUnpack(#[from] UnpackError),
+    #[error("Check command failed: {0}")]
+    Check(#[from] CheckError),
+    #[error("Latest block summary command failed: {0}")]
+    LatestBlockSummary(#[from] LatestBlockSummaryError),
+    #[error("Trie compact failed: {0}")]
+    TrieCompact(#[from] TrieCompactError),
+    #[error("Unsparse failed: {0}")]
+    Unsparse(#[from] UnsparseError),
+}

--- a/src/subcommands/archive.rs
+++ b/src/subcommands/archive.rs
@@ -1,6 +1,12 @@
 use std::process;
 
 use clap::{ArgMatches, Command};
+use thiserror::Error as ThisError;
+
+pub use create::Error as CreateError;
+pub use unpack::Error as UnpackError;
+
+use super::Error as SubcommandError;
 
 mod create;
 mod ring_buffer;
@@ -15,6 +21,23 @@ enum DisplayOrder {
     Unpack,
 }
 
+#[derive(ThisError, Debug)]
+pub enum Error {
+    #[error("create: {0}")]
+    Create(#[from] CreateError),
+    #[error("unpack: {0}")]
+    Unpack(#[from] UnpackError),
+}
+
+impl From<Error> for SubcommandError {
+    fn from(err: Error) -> Self {
+        match err {
+            Error::Create(create_err) => SubcommandError::ArchiveCreate(create_err),
+            Error::Unpack(unpack_err) => SubcommandError::ArchiveUnpack(unpack_err),
+        }
+    }
+}
+
 pub fn command(display_order: usize) -> Command<'static> {
     Command::new(COMMAND_NAME)
         .display_order(display_order)
@@ -23,14 +46,14 @@ pub fn command(display_order: usize) -> Command<'static> {
         .subcommand(unpack::command(DisplayOrder::Unpack as usize))
 }
 
-pub fn run(matches: &ArgMatches) -> bool {
+pub fn run(matches: &ArgMatches) -> Result<(), Error> {
     let (subcommand_name, matches) = matches.subcommand().unwrap_or_else(|| {
         process::exit(1);
     });
 
     match subcommand_name {
-        create::COMMAND_NAME => create::run(matches),
-        unpack::COMMAND_NAME => unpack::run(matches),
+        create::COMMAND_NAME => create::run(matches).map_err(Error::Create),
+        unpack::COMMAND_NAME => unpack::run(matches).map_err(Error::Unpack),
         _ => unreachable!("{} should be handled above", subcommand_name),
     }
 }

--- a/src/subcommands/archive/create.rs
+++ b/src/subcommands/archive/create.rs
@@ -59,14 +59,8 @@ pub fn command(display_order: usize) -> Command<'static> {
         )
 }
 
-pub fn run(matches: &ArgMatches) -> bool {
+pub fn run(matches: &ArgMatches) -> Result<(), Error> {
     let db_path = matches.value_of(DB).unwrap();
     let dest = matches.value_of(OUTPUT).unwrap();
-    let result = pack::create_archive(db_path, dest);
-
-    if let Err(error) = &result {
-        error!("Archive packing failed. {}", error);
-    }
-
-    result.is_ok()
+    pack::create_archive(db_path, dest)
 }

--- a/src/subcommands/archive/create.rs
+++ b/src/subcommands/archive/create.rs
@@ -11,6 +11,7 @@ use thiserror::Error as ThisError;
 use super::zstd_utils::Error as ZstdError;
 
 pub const COMMAND_NAME: &str = "create";
+const OVERWRITE: &str = "overwrite";
 const OUTPUT: &str = "output";
 const DB: &str = "db-dir";
 
@@ -29,6 +30,7 @@ pub enum Error {
 enum DisplayOrder {
     Db,
     Output,
+    Overwrite,
 }
 
 pub fn command(display_order: usize) -> Command<'static> {
@@ -57,10 +59,23 @@ pub fn command(display_order: usize) -> Command<'static> {
                 .value_name("FILE_PATH")
                 .help("Output file path for the compressed tar archive."),
         )
+        .arg(
+            Arg::new(OVERWRITE)
+                .display_order(DisplayOrder::Overwrite as usize)
+                .required(false)
+                .short('w')
+                .long(OVERWRITE)
+                .takes_value(false)
+                .help(
+                    "Overwrite an already existing archive file in destination \
+                    directory.",
+                ),
+        )
 }
 
 pub fn run(matches: &ArgMatches) -> Result<(), Error> {
     let db_path = matches.value_of(DB).unwrap();
     let dest = matches.value_of(OUTPUT).unwrap();
-    pack::create_archive(db_path, dest)
+    let overwrite = matches.is_present(OVERWRITE);
+    pack::create_archive(db_path, dest, overwrite)
 }

--- a/src/subcommands/archive/create/tests.rs
+++ b/src/subcommands/archive/create/tests.rs
@@ -86,10 +86,5 @@ fn archive_create_bad_input() {
     // Destination directory isn't empty.
     let root_dst = tempfile::tempdir().unwrap();
     let existing_file = NamedTempFile::new_in(&root_dst).unwrap();
-    assert!(pack::create_archive(
-        &src_dir,
-        existing_file.path(),
-        false,
-    )
-    .is_err());
+    assert!(pack::create_archive(&src_dir, existing_file.path(), false,).is_err());
 }

--- a/src/subcommands/archive/create/tests.rs
+++ b/src/subcommands/archive/create/tests.rs
@@ -62,6 +62,31 @@ fn archive_create_roundtrip() {
 }
 
 #[test]
+fn archive_create_overwrite() {
+    // Create the mock test directory with randomly-filled files.
+    let src_dir = &(*MOCK_DIR).0;
+    let test_payloads = &(*MOCK_DIR).1;
+    let dst_dir = tempfile::tempdir().unwrap();
+    let out_dir = tempfile::tempdir().unwrap();
+    let archive_path = dst_dir.path().join("test_archive.tar.zst");
+    // Create a mock existing file at the expected destination.
+    fs::write(&archive_path, "dummy input").unwrap();
+    // File already exists, so creating the archive without the overwrite flag
+    // should fail.
+    assert!(pack::create_archive(&src_dir, &archive_path, false).is_err());
+    // Create the compressed archive with the overwrite set.
+    assert!(pack::create_archive(&src_dir, &archive_path, true).is_ok());
+    // Unpack and then delete the archive.
+    unpack_mock_archive(&archive_path, &out_dir);
+    for idx in 0..NUM_TEST_FILES {
+        let contents = fs::read(out_dir.path().join(&format!("file_{}", idx))).unwrap();
+        if contents != test_payloads.payloads[idx] {
+            panic!("Contents of file {} are different from the original", idx);
+        }
+    }
+}
+
+#[test]
 fn archive_create_bad_input() {
     let src_dir = &(*MOCK_DIR).0;
     let root_dst = tempfile::tempdir().unwrap();
@@ -86,5 +111,5 @@ fn archive_create_bad_input() {
     // Destination directory isn't empty.
     let root_dst = tempfile::tempdir().unwrap();
     let existing_file = NamedTempFile::new_in(&root_dst).unwrap();
-    assert!(pack::create_archive(&src_dir, existing_file.path(), false,).is_err());
+    assert!(pack::create_archive(&src_dir, existing_file.path(), false).is_err());
 }

--- a/src/subcommands/archive/create/tests.rs
+++ b/src/subcommands/archive/create/tests.rs
@@ -50,7 +50,7 @@ fn archive_create_roundtrip() {
     let out_dir = tempfile::tempdir().unwrap();
     let archive_path = dst_dir.path().join("test_archive.tar.zst");
     // Create the compressed archive.
-    assert!(pack::create_archive(&src_dir, &archive_path).is_ok());
+    assert!(pack::create_archive(&src_dir, &archive_path, false).is_ok());
     // Unpack and then delete the archive.
     unpack_mock_archive(&archive_path, &out_dir);
     for idx in 0..NUM_TEST_FILES {
@@ -68,17 +68,28 @@ fn archive_create_bad_input() {
     let inexistent_file_path = root_dst.path().join("bogus_path");
 
     // Source doesn't exist.
-    assert!(pack::create_archive(&inexistent_file_path, &inexistent_file_path).is_err());
+    assert!(pack::create_archive(&inexistent_file_path, &inexistent_file_path, false).is_err());
 
     // Source is not a directory.
     let file = NamedTempFile::new().unwrap();
-    assert!(pack::create_archive(file.path(), &inexistent_file_path).is_err());
+    assert!(pack::create_archive(file.path(), &inexistent_file_path, false).is_err());
 
     // Destination directory doesn't exist.
     let root_dst = tempfile::tempdir().unwrap();
     assert!(pack::create_archive(
         &src_dir,
-        root_dst.path().join("bogus_dest/test_archive.tar.zst")
+        root_dst.path().join("bogus_dest/test_archive.tar.zst"),
+        false,
+    )
+    .is_err());
+
+    // Destination directory isn't empty.
+    let root_dst = tempfile::tempdir().unwrap();
+    let existing_file = NamedTempFile::new_in(&root_dst).unwrap();
+    assert!(pack::create_archive(
+        &src_dir,
+        existing_file.path(),
+        false,
     )
     .is_err());
 }

--- a/src/subcommands/archive/unpack.rs
+++ b/src/subcommands/archive/unpack.rs
@@ -117,7 +117,7 @@ pub fn command(display_order: usize) -> Command<'static> {
         )
 }
 
-pub fn run(matches: &ArgMatches) -> bool {
+pub fn run(matches: &ArgMatches) -> Result<(), Error> {
     let input = matches
         .value_of(URL)
         .map(|url| Input::Url(url.to_string()))
@@ -128,11 +128,5 @@ pub fn run(matches: &ArgMatches) -> bool {
                 .unwrap_or_else(|| panic!("Should have one of {} or {}", FILE, URL))
         });
     let dest = matches.value_of(OUTPUT).unwrap();
-    let result = unpack(input, dest);
-
-    if let Err(error) = &result {
-        error!("Archive unpack failed. {}", error);
-    }
-
-    result.is_ok()
+    unpack(input, dest)
 }

--- a/src/subcommands/archive/unpack/download_stream.rs
+++ b/src/subcommands/archive/unpack/download_stream.rs
@@ -1,18 +1,23 @@
-use std::{io::Read, path::Path, result::Result};
+use std::{
+    io::{Error as IoError, Read},
+    path::Path,
+    result::Result,
+};
 
 use futures::{io, AsyncRead, AsyncReadExt, TryStreamExt};
 use log::info;
 use tokio::runtime::{Builder as TokioRuntimeBuilder, Runtime};
 
 use super::Error;
-use crate::subcommands::archive::{tar_utils, zstd_utils};
+use crate::{
+    common::progress::ProgressTracker,
+    subcommands::archive::{tar_utils, zstd_utils},
+};
 
-pub struct HttpStream {
+struct HttpStream {
     runtime: Runtime,
     reader: Box<dyn AsyncRead + Unpin>,
-    pub stream_length: Option<usize>,
-    pub total_bytes_read: usize,
-    pub progress: u64,
+    maybe_progress_tracker: Option<ProgressTracker>,
 }
 
 impl HttpStream {
@@ -21,13 +26,9 @@ impl HttpStream {
             let response_fut = reqwest::get(url).await;
             match response_fut {
                 Ok(response) => {
-                    let maybe_len = response.content_length().map(|len| {
+                    let maybe_len = response.content_length().and_then(|len| {
                         info!("Download size: {} bytes.", len);
-                        // Highly unlikely scenario where we can't convert `u64` to `usize`.
-                        // This would mean we're running on a 32-bit or older system and the
-                        // content length cannot be represented in that system's pointer size.
-                        len.try_into()
-                            .expect("Couldn't convert content length from u64 to usize")
+                        len.try_into().ok()
                     });
                     Ok((
                         response.bytes_stream().map_err(|reqwest_err| {
@@ -45,25 +46,29 @@ impl HttpStream {
         Ok(Self {
             runtime,
             reader,
-            stream_length: maybe_content_length,
-            total_bytes_read: 0,
-            progress: 1,
+            maybe_progress_tracker: maybe_content_length.map(ProgressTracker::new),
         })
     }
 }
 
 impl Read for HttpStream {
-    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+    fn read(&mut self, buf: &mut [u8]) -> Result<usize, IoError> {
         let fut = async { self.reader.read(buf).await };
         let bytes_read = self.runtime.block_on(fut)?;
-        self.total_bytes_read += bytes_read;
-        if let Some(stream_len) = self.stream_length {
-            while self.total_bytes_read > (stream_len * self.progress as usize) / 20 {
-                info!("Download {}% complete...", self.progress * 5);
-                self.progress += 1;
-            }
+        if let Some(progress_tracker) = self.maybe_progress_tracker.as_mut() {
+            progress_tracker.advance(bytes_read, |completion| {
+                info!("Download {}% complete...", completion)
+            });
         }
         Ok(bytes_read)
+    }
+}
+
+impl Drop for HttpStream {
+    fn drop(&mut self) {
+        if let Some(progress_tracker) = self.maybe_progress_tracker.take() {
+            progress_tracker.finish(|| info!("Download complete."));
+        }
     }
 }
 
@@ -77,6 +82,5 @@ pub fn download_and_unpack_archive<P: AsRef<Path>>(url: &str, dest: P) -> Result
     let decoder = zstd_utils::zstd_decode_stream(http_stream)?;
     let mut unpacker = tar_utils::unarchive_stream(decoder);
     unpacker.unpack(&dest).map_err(Error::Streaming)?;
-    info!("Download complete.");
     Ok(())
 }

--- a/src/subcommands/archive/unpack/file_stream.rs
+++ b/src/subcommands/archive/unpack/file_stream.rs
@@ -1,9 +1,51 @@
-use std::{fs::OpenOptions, path::Path, result::Result};
+use std::{
+    fs::OpenOptions,
+    io::{Error as IoError, Read},
+    path::Path,
+    result::Result,
+};
 
 use log::info;
 
 use super::Error;
-use crate::subcommands::archive::{tar_utils, zstd_utils};
+use crate::{
+    common::progress::ProgressTracker,
+    subcommands::archive::{tar_utils, zstd_utils},
+};
+
+struct FileStream<R> {
+    reader: R,
+    maybe_progress_tracker: Option<ProgressTracker>,
+}
+
+impl<R: Read> FileStream<R> {
+    fn new(reader: R, maybe_len: Option<usize>) -> Self {
+        Self {
+            reader,
+            maybe_progress_tracker: maybe_len.map(ProgressTracker::new),
+        }
+    }
+}
+
+impl<R: Read> Read for FileStream<R> {
+    fn read(&mut self, buf: &mut [u8]) -> Result<usize, IoError> {
+        let bytes_read = self.reader.read(buf)?;
+        if let Some(progress_tracker) = self.maybe_progress_tracker.as_mut() {
+            progress_tracker.advance(bytes_read, |completion| {
+                info!("Archive reading {}% complete...", completion)
+            });
+        }
+        Ok(bytes_read)
+    }
+}
+
+impl<R> Drop for FileStream<R> {
+    fn drop(&mut self) {
+        if let Some(progress_tracker) = self.maybe_progress_tracker.take() {
+            progress_tracker.finish(|| info!("Decompression complete."));
+        }
+    }
+}
 
 pub fn file_stream_and_unpack_archive<P1: AsRef<Path>, P2: AsRef<Path>>(
     path: P1,
@@ -13,10 +55,13 @@ pub fn file_stream_and_unpack_archive<P1: AsRef<Path>, P2: AsRef<Path>>(
         .read(true)
         .open(path)
         .map_err(Error::Source)?;
-
-    let decoder = zstd_utils::zstd_decode_stream(input_file)?;
+    let file_len: Option<usize> = input_file
+        .metadata()
+        .ok()
+        .and_then(|metadata| metadata.len().try_into().ok());
+    let file_stream = FileStream::new(input_file, file_len);
+    let decoder = zstd_utils::zstd_decode_stream(file_stream)?;
     let mut unpacker = tar_utils::unarchive_stream(decoder);
     unpacker.unpack(dest).map_err(Error::Streaming)?;
-    info!("Decompression complete.");
     Ok(())
 }

--- a/src/subcommands/archive/unpack/tests.rs
+++ b/src/subcommands/archive/unpack/tests.rs
@@ -207,8 +207,8 @@ fn archive_unpack_existing_destination() {
 
     // Create the destination file before downloading.
     let _ = File::create(&dest_path).unwrap();
-    // Download should fail because the file is already present. Address doesn't
-    // matter because the file check is performed first.
+    // Download should fail because a file is already present at the destination
+    // directory. Address doesn't matter because the file check is performed first.
     assert!(download_stream::download_and_unpack_archive("bogus_address", dest_path).is_err());
 }
 

--- a/src/subcommands/check.rs
+++ b/src/subcommands/check.rs
@@ -94,7 +94,7 @@ pub fn run(matches: &ArgMatches) -> Result<(), Error> {
         .value_of(START_AT)
         .expect("should have a default")
         .parse()
-        .expect("Value of \"--start-at\" must be an integer.");
+        .unwrap_or_else(|_| panic!("Value of \"--{}\" must be an integer.", START_AT));
 
     check_db(path, failfast, specific, start_at)
 }

--- a/src/subcommands/latest_block_summary.rs
+++ b/src/subcommands/latest_block_summary.rs
@@ -3,14 +3,34 @@ mod read_db;
 #[cfg(test)]
 mod tests;
 
-use std::path::Path;
+use std::{io::Error as IoError, path::Path};
 
+use bincode::Error as BincodeError;
 use clap::{Arg, ArgMatches, Command};
-use log::error;
+use lmdb::Error as LmdbError;
+use serde_json::Error as SerializationError;
+use thiserror::Error as ThisError;
 
 pub const COMMAND_NAME: &str = "latest-block-summary";
 const DB_PATH: &str = "db-path";
 const OUTPUT: &str = "output";
+
+/// Errors encountered when operating on the storage database.
+#[derive(Debug, ThisError)]
+pub enum Error {
+    #[error("No blocks found in the block header database")]
+    EmptyDatabase,
+    /// Parsing error on entry at index in the database.
+    #[error("Error parsing element {0}: {1}")]
+    Parsing(usize, BincodeError),
+    /// Database operation error.
+    #[error("Error operating the database: {0}")]
+    Database(#[from] LmdbError),
+    #[error("Error serializing output: {0}")]
+    Serialize(#[from] SerializationError),
+    #[error("Error writing output: {0}")]
+    Output(#[from] IoError),
+}
 
 enum DisplayOrder {
     DbPath,
@@ -48,14 +68,8 @@ pub fn command(display_order: usize) -> Command<'static> {
         )
 }
 
-pub fn run(matches: &ArgMatches) -> bool {
+pub fn run(matches: &ArgMatches) -> Result<(), Error> {
     let path = Path::new(matches.value_of(DB_PATH).expect("should have db-path arg"));
     let output = matches.value_of(OUTPUT).map(Path::new);
-    let result = read_db::latest_block_summary(path, output);
-
-    if let Err(error) = &result {
-        error!("Latest block summary failed. {}", error);
-    }
-
-    result.is_ok()
+    read_db::latest_block_summary(path, output)
 }

--- a/src/subcommands/latest_block_summary.rs
+++ b/src/subcommands/latest_block_summary.rs
@@ -54,7 +54,7 @@ pub fn command(display_order: usize) -> Command<'static> {
                 .long(DB_PATH)
                 .takes_value(true)
                 .value_name("DB_PATH")
-                .help("Path to the storage.lmdb file."),
+                .help("Path of the directory with the `storage.lmdb` file."),
         )
         .arg(
             Arg::new(OUTPUT)

--- a/src/subcommands/latest_block_summary.rs
+++ b/src/subcommands/latest_block_summary.rs
@@ -13,6 +13,7 @@ use thiserror::Error as ThisError;
 
 pub const COMMAND_NAME: &str = "latest-block-summary";
 const DB_PATH: &str = "db-path";
+const OVERWRITE: &str = "overwrite";
 const OUTPUT: &str = "output";
 
 /// Errors encountered when operating on the storage database.
@@ -35,6 +36,7 @@ pub enum Error {
 enum DisplayOrder {
     DbPath,
     Output,
+    Overwrite,
 }
 
 pub fn command(display_order: usize) -> Command<'static> {
@@ -66,10 +68,24 @@ pub fn command(display_order: usize) -> Command<'static> {
                     If unspecified, defaults to standard output.",
                 ),
         )
+        .arg(
+            Arg::new(OVERWRITE)
+                .display_order(DisplayOrder::Overwrite as usize)
+                .required(false)
+                .short('w')
+                .long(OVERWRITE)
+                .takes_value(false)
+                .requires(OUTPUT)
+                .help(
+                    "Overwrite an already existing output file in destination \
+                    directory.",
+                ),
+        )
 }
 
 pub fn run(matches: &ArgMatches) -> Result<(), Error> {
     let path = Path::new(matches.value_of(DB_PATH).expect("should have db-path arg"));
     let output = matches.value_of(OUTPUT).map(Path::new);
-    read_db::latest_block_summary(path, output)
+    let overwrite = matches.is_present(OVERWRITE);
+    read_db::latest_block_summary(path, output, overwrite)
 }

--- a/src/subcommands/latest_block_summary/block_info.rs
+++ b/src/subcommands/latest_block_summary/block_info.rs
@@ -60,16 +60,15 @@ impl BlockInfo {
 
 pub fn parse_network_name<P: AsRef<Path>>(path: P) -> Result<String, IoError> {
     let canon_path = fs::canonicalize(path)?;
-    let network_name = canon_path
-        .parent()
-        .ok_or_else(|| IoError::from(ErrorKind::NotFound))?
-        .file_name()
-        .ok_or_else(|| {
-            IoError::new(
-                ErrorKind::InvalidInput,
-                "Path cannot be represented in UTF-8",
-            )
-        })?;
+    if !canon_path.is_dir() {
+        return Err(IoError::new(ErrorKind::InvalidInput, "Not a directory"));
+    }
+    let network_name = canon_path.file_name().ok_or_else(|| {
+        IoError::new(
+            ErrorKind::InvalidInput,
+            "Path cannot be represented in UTF-8",
+        )
+    })?;
     network_name
         .to_str()
         .ok_or_else(|| {

--- a/src/subcommands/latest_block_summary/read_db.rs
+++ b/src/subcommands/latest_block_summary/read_db.rs
@@ -11,7 +11,7 @@ use serde_json::{self, Error as SerializationError};
 
 use casper_node::types::BlockHeader;
 
-use crate::common::db::{self, BlockHeaderDatabase, Database};
+use crate::common::db::{self, BlockHeaderDatabase, Database, STORAGE_FILE_NAME};
 
 use super::{
     block_info::{parse_network_name, BlockInfo},
@@ -62,7 +62,8 @@ pub fn latest_block_summary<P1: AsRef<Path>, P2: AsRef<Path>>(
     output: Option<P2>,
     overwrite: bool,
 ) -> Result<(), Error> {
-    let env = db::db_env(db_path.as_ref())?;
+    let storage_path = db_path.as_ref().join(STORAGE_FILE_NAME);
+    let env = db::db_env(&storage_path)?;
     // Validate the output file early so that, in case this fails
     // we don't unnecessarily read the whole database.
     let out_writer: Box<dyn Write> = if let Some(out_path) = output {

--- a/src/subcommands/latest_block_summary/read_db.rs
+++ b/src/subcommands/latest_block_summary/read_db.rs
@@ -29,7 +29,7 @@ fn get_highest_block(env: &Environment, log_progress: bool) -> Result<BlockHeade
     let mut max_height = 0u64;
     let mut max_height_key = None;
 
-    let maybe_entry_count = lmdb_utils::entries_count(&txn, db).ok();
+    let maybe_entry_count = lmdb_utils::entry_count(&txn, db).ok();
     let mut maybe_progress_tracker = None;
 
     if let Ok(mut cursor) = txn.open_ro_cursor(db) {

--- a/src/subcommands/latest_block_summary/read_db.rs
+++ b/src/subcommands/latest_block_summary/read_db.rs
@@ -1,38 +1,19 @@
 use std::{
     fs::OpenOptions,
-    io::{self, Error as IoError, Write},
+    io::{self, Write},
     path::Path,
     result::Result,
 };
 
-use bincode::Error as BincodeError;
-use lmdb::{Cursor, Environment, Error as LmdbError, Transaction};
-use log::{error, warn};
+use lmdb::{Cursor, Environment, Transaction};
+use log::warn;
 use serde_json::{self, Error as SerializationError};
-use thiserror::Error;
 
 use casper_node::types::BlockHeader;
 
 use crate::common::db::{self, BlockHeaderDatabase, Database};
 
-use super::block_info::{parse_network_name, BlockInfo};
-
-/// Errors encountered when operating on the storage database.
-#[derive(Debug, Error)]
-pub enum Error {
-    #[error("No blocks found in the block header database")]
-    EmptyDatabase,
-    /// Parsing error on entry at index in the database.
-    #[error("Error parsing element {0}: {1}")]
-    Parsing(usize, BincodeError),
-    /// Database operation error.
-    #[error("Error operating the database: {0}")]
-    Database(#[from] LmdbError),
-    #[error("Error serializing output: {0}")]
-    Serialize(#[from] SerializationError),
-    #[error("Error writing output: {0}")]
-    Output(#[from] IoError),
-}
+use super::{block_info::{parse_network_name, BlockInfo}, Error};
 
 fn get_highest_block(env: &Environment) -> Result<BlockHeader, Error> {
     let txn = env.begin_ro_txn()?;

--- a/src/subcommands/latest_block_summary/read_db.rs
+++ b/src/subcommands/latest_block_summary/read_db.rs
@@ -6,25 +6,42 @@ use std::{
 };
 
 use lmdb::{Cursor, Environment, Transaction};
-use log::warn;
+use log::{info, warn};
 use serde_json::{self, Error as SerializationError};
 
 use casper_node::types::BlockHeader;
 
-use crate::common::db::{self, BlockHeaderDatabase, Database, STORAGE_FILE_NAME};
+use crate::common::{
+    db::{self, BlockHeaderDatabase, Database, STORAGE_FILE_NAME},
+    lmdb_utils,
+    progress::ProgressTracker,
+};
 
 use super::{
     block_info::{parse_network_name, BlockInfo},
     Error,
 };
 
-fn get_highest_block(env: &Environment) -> Result<BlockHeader, Error> {
+fn get_highest_block(env: &Environment, log_progress: bool) -> Result<BlockHeader, Error> {
     let txn = env.begin_ro_txn()?;
     let db = unsafe { txn.open_db(Some(BlockHeaderDatabase::db_name()))? };
 
     let mut max_height = 0u64;
     let mut max_height_key = None;
+
+    let maybe_entry_count = lmdb_utils::entries_count(&txn, db).ok();
+    let mut maybe_progress_tracker = None;
+
     if let Ok(mut cursor) = txn.open_ro_cursor(db) {
+        if log_progress {
+            match maybe_entry_count {
+                Some(entry_count) => {
+                    maybe_progress_tracker = Some(ProgressTracker::new(entry_count))
+                }
+                None => warn!("Unable to count db entries, progress will not be logged."),
+            }
+        }
+
         for (idx, (raw_key, raw_val)) in cursor.iter().enumerate() {
             let header: BlockHeader = bincode::deserialize(raw_val)
                 .map_err(|bincode_err| Error::Parsing(idx, bincode_err))?;
@@ -32,6 +49,17 @@ fn get_highest_block(env: &Environment) -> Result<BlockHeader, Error> {
                 max_height = header.height();
                 let _ = max_height_key.replace(raw_key);
             }
+
+            if let Some(progress_tracker) = maybe_progress_tracker.as_mut() {
+                progress_tracker.advance(1, |completion| {
+                    info!("Database parsing {}% complete...", completion)
+                });
+            }
+        }
+
+        if let Some(progress_tracker) = maybe_progress_tracker.take() {
+            progress_tracker
+                .finish(|| info!("Database parsing complete, creating highest block metadata."));
         }
     }
 
@@ -64,6 +92,7 @@ pub fn latest_block_summary<P1: AsRef<Path>, P2: AsRef<Path>>(
 ) -> Result<(), Error> {
     let storage_path = db_path.as_ref().join(STORAGE_FILE_NAME);
     let env = db::db_env(&storage_path)?;
+    let mut log_progress = false;
     // Validate the output file early so that, in case this fails
     // we don't unnecessarily read the whole database.
     let out_writer: Box<dyn Write> = if let Some(out_path) = output {
@@ -71,6 +100,7 @@ pub fn latest_block_summary<P1: AsRef<Path>, P2: AsRef<Path>>(
             .create_new(!overwrite)
             .write(true)
             .open(out_path)?;
+        log_progress = true;
         Box::new(file)
     } else {
         Box::new(io::stdout())
@@ -83,7 +113,7 @@ pub fn latest_block_summary<P1: AsRef<Path>, P2: AsRef<Path>>(
         }
     };
 
-    let highest_block = get_highest_block(&env)?;
+    let highest_block = get_highest_block(&env, log_progress)?;
     let block_info = BlockInfo::new(network_name, highest_block);
     dump_block_info(&block_info, out_writer)?;
 

--- a/src/subcommands/latest_block_summary/read_db.rs
+++ b/src/subcommands/latest_block_summary/read_db.rs
@@ -13,7 +13,10 @@ use casper_node::types::BlockHeader;
 
 use crate::common::db::{self, BlockHeaderDatabase, Database};
 
-use super::{block_info::{parse_network_name, BlockInfo}, Error};
+use super::{
+    block_info::{parse_network_name, BlockInfo},
+    Error,
+};
 
 fn get_highest_block(env: &Environment) -> Result<BlockHeader, Error> {
     let txn = env.begin_ro_txn()?;
@@ -57,12 +60,16 @@ pub(crate) fn dump_block_info<W: Write + ?Sized>(
 pub fn latest_block_summary<P1: AsRef<Path>, P2: AsRef<Path>>(
     db_path: P1,
     output: Option<P2>,
+    overwrite: bool,
 ) -> Result<(), Error> {
     let env = db::db_env(db_path.as_ref())?;
     // Validate the output file early so that, in case this fails
     // we don't unnecessarily read the whole database.
     let out_writer: Box<dyn Write> = if let Some(out_path) = output {
-        let file = OpenOptions::new().create(true).write(true).open(out_path)?;
+        let file = OpenOptions::new()
+            .create_new(!overwrite)
+            .write(true)
+            .open(out_path)?;
         Box::new(file)
     } else {
         Box::new(io::stdout())

--- a/src/subcommands/trie_compact.rs
+++ b/src/subcommands/trie_compact.rs
@@ -43,7 +43,7 @@ pub enum Error {
     #[error("Path {0} cannot be created/resolved: {1}")]
     InvalidPath(PathBuf, IoError),
     /// Error while operating on LMDB.
-    #[error("Error operation on LMDB: {0}")]
+    #[error("Error while operating on LMDB: {0}")]
     LmdbOperation(LmdbError),
     /// A block of specific height is missing from the storage.
     #[error("Storage database is missing block {0}")]

--- a/src/subcommands/trie_compact/tests.rs
+++ b/src/subcommands/trie_compact/tests.rs
@@ -17,8 +17,9 @@ use casper_types::bytesrepr::{Bytes, ToBytes};
 static DEFAULT_MAX_DB_SIZE: Lazy<usize> = Lazy::new(|| super::DEFAULT_MAX_DB_SIZE.parse().unwrap());
 
 use super::{
-    compact::{self, DestinationOptions, Error, TRIE_STORE_FILE_NAME},
+    compact::{self, DestinationOptions, TRIE_STORE_FILE_NAME},
     utils::{create_execution_engine, create_storage, load_execution_engine},
+    Error,
 };
 
 #[derive(Clone, Debug, PartialEq)]

--- a/src/subcommands/unsparse.rs
+++ b/src/subcommands/unsparse.rs
@@ -88,8 +88,8 @@ mod tests {
 
     #[test]
     fn should_reduce_lmdb_file_size() {
-        let fixture = LmdbTestFixture::new(Some("a"));
-        let db_path = fixture.tmp_file.path();
+        let fixture = LmdbTestFixture::new(Some("a"), None);
+        let db_path = fixture.file_path.as_path();
         let db_size = || {
             fs::metadata(db_path)
                 .unwrap_or_else(|error| {

--- a/src/subcommands/unsparse.rs
+++ b/src/subcommands/unsparse.rs
@@ -1,11 +1,26 @@
-use std::{fs, path::Path};
+use std::{
+    fs,
+    io::Error as IoError,
+    path::{Path, PathBuf},
+};
 
 use clap::{Arg, ArgMatches, Command};
-use lmdb::{Environment, EnvironmentFlags};
+use lmdb::{Environment, EnvironmentFlags, Error as LmdbError};
 use log::{error, info};
+use thiserror::Error as ThisError;
 
 pub const COMMAND_NAME: &str = "unsparse";
 const DB_PATH: &str = "file-path";
+
+#[derive(ThisError, Debug)]
+pub enum Error {
+    #[error("Failed to get metadata for {0}: {1}")]
+    Metadata(PathBuf, IoError),
+    #[error("Failed to open lmdb database at {0}: {1}")]
+    Lmdb(PathBuf, LmdbError),
+    #[error("Failed to reduce size of {0} from {1} bytes")]
+    Size(PathBuf, u64),
+}
 
 pub fn command(display_order: usize) -> Command<'static> {
     Command::new(COMMAND_NAME)
@@ -23,7 +38,7 @@ pub fn command(display_order: usize) -> Command<'static> {
         )
 }
 
-pub fn run(matches: &ArgMatches) -> bool {
+pub fn run(matches: &ArgMatches) -> Result<(), Error> {
     let path = Path::new(
         matches
             .value_of(DB_PATH)
@@ -32,35 +47,21 @@ pub fn run(matches: &ArgMatches) -> bool {
     unsparse(path)
 }
 
-fn unsparse(path: &Path) -> bool {
-    let size_before = match fs::metadata(path) {
-        Ok(metadata) => metadata.len(),
-        Err(error) => {
-            error!("Failed to get metadata for {}: {}", path.display(), error);
-            return false;
-        }
-    };
+fn unsparse(path: &Path) -> Result<(), Error> {
+    let size_before = fs::metadata(path)
+        .map(|metadata| metadata.len())
+        .map_err(|io_err| Error::Metadata(path.to_path_buf(), io_err))?;
 
-    let _env = match Environment::new()
+    let _env = Environment::new()
         .set_flags(EnvironmentFlags::WRITE_MAP | EnvironmentFlags::NO_SUB_DIR)
         .set_max_dbs(100)
         .set_map_size(1)
         .open(path)
-    {
-        Ok(env) => env,
-        Err(error) => {
-            error!("Failed to open {}: {}", path.display(), error);
-            return false;
-        }
-    };
+        .map_err(|lmdb_err| Error::Lmdb(path.to_path_buf(), lmdb_err))?;
 
-    let size_after = match fs::metadata(path) {
-        Ok(metadata) => metadata.len(),
-        Err(error) => {
-            error!("Failed to get metadata for {}: {}", path.display(), error);
-            return false;
-        }
-    };
+    let size_after = fs::metadata(path)
+        .map(|metadata| metadata.len())
+        .map_err(|io_err| Error::Metadata(path.to_path_buf(), io_err))?;
 
     if size_before > size_after {
         info!(
@@ -69,14 +70,14 @@ fn unsparse(path: &Path) -> bool {
             size_before,
             size_after
         );
-        true
+        Ok(())
     } else {
         error!(
             "Failed to reduce size of {} from {} bytes.",
             path.display(),
             size_before
         );
-        false
+        Err(Error::Size(path.to_path_buf(), size_before))
     }
 }
 
@@ -97,11 +98,11 @@ mod tests {
                 .len()
         };
         let size_before = db_size();
-        assert!(unsparse(db_path), "unsparse should succeed");
+        unsparse(db_path).expect("unsparse should succeed");
         let size_after = db_size();
         assert!(size_after < size_before, "unsparse should reduce file size");
 
-        assert!(!unsparse(db_path), "repeat unsparse should fail");
+        assert!(unsparse(db_path).is_err(), "repeat unsparse should fail");
         assert_eq!(db_size(), size_after, "file size should be unchanged");
     }
 }


### PR DESCRIPTION
Fixes #14 #19 

This PR cleans up various parts of the codebase which accumulated technical debt. Here are the main points:
- Have proper error handling and propagation through subcommands (using `thiserror`).
- Added `--overwrite` option to subcommands which didn't have it already and write files to the file system.
- Added progress tracker util which logs progress for long running tasks. The exception is `archive create` where the function we are using from `tar` is a blackbox which takes file paths as input, so there was no way to integrate the progress tracker.
- Added util for counting entries in an LMDB database. There is a [PR open in `lmdb`](https://github.com/danburkert/lmdb-rs/pull/50) to do this, but the project has been inactive for a long time so I don't think it will get merged soon.
- Made `DB-PATH` parameter consistent across the codebase. It now always means the path of the directory with the `storage.lmdb` file.

Added @sacherjj for review of the CLI usage and overall UX.