### PR TITLE
Add `extract-slice` subcommand

### DIFF
--- a/.github/workflows/ci-casper-db-utils.yml
+++ b/.github/workflows/ci-casper-db-utils.yml
@@ -33,7 +33,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: audit
-          args: --deny warnings --ignore RUSTSEC-2022-0001 --ignore RUSTSEC-2020-0071 --ignore RUSTSEC-2022-0041 --ignore RUSTSEC-2021-0139 --ignore RUSTSEC-2022-0061
+          args: --deny warnings --ignore RUSTSEC-2022-0001 --ignore RUSTSEC-2020-0071 --ignore RUSTSEC-2021-0139 --ignore RUSTSEC-2022-0061 --ignore RUSTSEC-2021-0145 --ignore RUSTSEC-2021-0146
 
       - name: Clippy
         uses: actions-rs/cargo@v1

--- a/.github/workflows/ci-casper-db-utils.yml
+++ b/.github/workflows/ci-casper-db-utils.yml
@@ -33,7 +33,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: audit
-          args: --deny warnings --ignore RUSTSEC-2022-0001 --ignore RUSTSEC-2020-0071 --ignore RUSTSEC-2021-0139 --ignore RUSTSEC-2022-0061 --ignore RUSTSEC-2021-0145 --ignore RUSTSEC-2021-0146
+          args: --deny warnings --ignore RUSTSEC-2022-0001 --ignore RUSTSEC-2020-0071 --ignore RUSTSEC-2021-0139 --ignore RUSTSEC-2022-0061 --ignore RUSTSEC-2021-0145 --ignore RUSTSEC-2021-0146 --ignore RUSTSEC-2022-0041
 
       - name: Clippy
         uses: actions-rs/cargo@v1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,9 +14,9 @@ dependencies = [
 
 [[package]]
 name = "addr2line"
-version = "0.17.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9ecd88a8c8378ca913a680cd98f0f13ac67383d35993f86c90a70e3f137816b"
+checksum = "a76fd60b23679b7d19bd066031410fb7e458ccc5e958eb5c325888ce4baedc97"
 dependencies = [
  "gimli",
 ]
@@ -29,9 +29,9 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.19"
+version = "0.7.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4f55bd91a0978cbfd91c457a164bab8b4001c833b7f323132c0a4e1922dd44e"
+checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
 dependencies = [
  "memchr",
 ]
@@ -71,9 +71,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.66"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "216261ddc8289130e551ddcd5ce8a064710c0d064a4d2895c67151c92b5443f6"
+checksum = "224afbd727c3d6e4b90103ece64b8d1b67fbb1973b1046c2281eed3f3803f800"
 
 [[package]]
 name = "async-compression"
@@ -91,9 +91,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.58"
+version = "0.1.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e805d94e6b5001b651426cf4cd446b1ab5f319d27bab5c644f61de0a804360c"
+checksum = "1cd7fce9ba8c3c042128ce72d8b2ddbf3a05747efb67ea0313c635e10bda47a2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -115,7 +115,7 @@ version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.1.19",
  "libc",
  "winapi",
 ]
@@ -128,9 +128,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "backtrace"
-version = "0.3.66"
+version = "0.3.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cab84319d616cfb654d03394f38ab7e6f0919e181b1b57e1fd15e7fb4077d9a7"
+checksum = "233d376d6d185f2a3093e58f283f60f880315b6c60075b01f36b3b85154564ca"
 dependencies = [
  "addr2line",
  "cc",
@@ -152,6 +152,12 @@ name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
+name = "base64"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
 
 [[package]]
 name = "bincode"
@@ -236,9 +242,9 @@ dependencies = [
 
 [[package]]
 name = "brotli-decompressor"
-version = "2.3.2"
+version = "2.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ad2d4653bf5ca36ae797b1f4bb4dbddb60ce49ca4aed8a2ce4829f60425b80"
+checksum = "4b6561fd3f895a11e8f72af2cb7d22e08366bebc2b6b57f7744c4bda27034744"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -256,9 +262,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.11.1"
+version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "572f695136211188308f16ad2ca5c851a712c464060ae6974944458eb83880ba"
+checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
 
 [[package]]
 name = "byteorder"
@@ -268,9 +274,9 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
-version = "1.2.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec8a7b6a70fde80372154c65702f00a0f56f3e1c36abbc6c440484be248856db"
+checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
 
 [[package]]
 name = "cache-padded"
@@ -379,7 +385,7 @@ dependencies = [
  "async-trait",
  "backtrace",
  "base16",
- "base64",
+ "base64 0.13.1",
  "bincode",
  "bytes",
  "casper-execution-engine",
@@ -480,7 +486,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13e82a13d1784104fd021a38da56c69da94e84b26b03c2cf3d8da3895a16c8c"
 dependencies = [
  "base16",
- "base64",
+ "base64 0.13.1",
  "bitflags",
  "blake2",
  "datasize",
@@ -505,9 +511,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.76"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76a284da2e6fe2092f2353e51713435363112dfd60030e22add80be333fb928f"
+checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
 dependencies = [
  "jobserver",
 ]
@@ -534,7 +540,7 @@ dependencies = [
  "js-sys",
  "num-integer",
  "num-traits",
- "time 0.1.44",
+ "time 0.1.45",
  "wasm-bindgen",
  "winapi",
 ]
@@ -768,9 +774,9 @@ dependencies = [
 
 [[package]]
 name = "cxx"
-version = "1.0.81"
+version = "1.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97abf9f0eca9e52b7f81b945524e76710e6cb2366aead23b7d4fbf72e281f888"
+checksum = "86d3488e7665a7a483b57e25bdd90d0aeb2bc7608c8d0346acf2ad3f1caf1d62"
 dependencies = [
  "cc",
  "cxxbridge-flags",
@@ -780,9 +786,9 @@ dependencies = [
 
 [[package]]
 name = "cxx-build"
-version = "1.0.81"
+version = "1.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cc32cc5fea1d894b77d269ddb9f192110069a8a9c1f1d441195fba90553dea3"
+checksum = "48fcaf066a053a41a81dfb14d57d99738b767febb8b735c3016e469fac5da690"
 dependencies = [
  "cc",
  "codespan-reporting",
@@ -795,15 +801,15 @@ dependencies = [
 
 [[package]]
 name = "cxxbridge-flags"
-version = "1.0.81"
+version = "1.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ca220e4794c934dc6b1207c3b42856ad4c302f2df1712e9f8d2eec5afaacf1f"
+checksum = "a2ef98b8b717a829ca5603af80e1f9e2e48013ab227b68ef37872ef84ee479bf"
 
 [[package]]
 name = "cxxbridge-macro"
-version = "1.0.81"
+version = "1.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b846f081361125bfc8dc9d3940c84e1fd83ba54bbca7b17cd29483c828be0704"
+checksum = "086c685979a698443656e5cf7856c95c642295a38599f12fb1ff76fb28d19892"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -812,9 +818,9 @@ dependencies = [
 
 [[package]]
 name = "datasize"
-version = "0.2.11"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6eeb75c8424b31fc9e13aa703f73e40aa9b7e3c0d22059162f61abe18f24128b"
+checksum = "3319c13ed12c1ce89494db62541bc66759c8870c3562bdf7b25b930420a00432"
 dependencies = [
  "datasize_derive",
  "fake_instant",
@@ -825,9 +831,9 @@ dependencies = [
 
 [[package]]
 name = "datasize_derive"
-version = "0.2.11"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecd3ee63556774dd6d8a6b98416475dd5e35872985699bbb19c4d7ad4ccecaff"
+checksum = "4abd50b37ab87677c31190aad6b4186be9993a618ff753c4b007551de6841ee8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -876,9 +882,9 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.10.5"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adfbc57365a37acbd2ebf2b64d7e69bb766e2fea813521ed536f5d0520dcf86c"
+checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
 dependencies = [
  "block-buffer 0.10.3",
  "crypto-common",
@@ -892,9 +898,9 @@ checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
 
 [[package]]
 name = "dyn-clone"
-version = "1.0.9"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f94fa09c2aeea5b8839e414b7b841bf429fd25b9c522116ac97ee87856d88b2"
+checksum = "c9b0705efd4599c15a38151f4721f7bc388306f61084d3bfd50bd07fbca5cb60"
 
 [[package]]
 name = "ecdsa"
@@ -946,9 +952,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.8.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
+checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
 
 [[package]]
 name = "elliptic-curve"
@@ -970,9 +976,9 @@ dependencies = [
 
 [[package]]
 name = "encoding_rs"
-version = "0.8.31"
+version = "0.8.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9852635589dc9f9ea1b6fe9f05b50ef208c85c834a562f0c6abb1c475736ec2b"
+checksum = "071a31f4ee85403370b58aca746f01041ede6f0da2730960ad001edc2b71b394"
 dependencies = [
  "cfg-if 1.0.0",
 ]
@@ -1013,9 +1019,9 @@ dependencies = [
 
 [[package]]
 name = "erased-serde"
-version = "0.3.23"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54558e0ba96fbe24280072642eceb9d7d442e32c7ec0ea9e7ecd7b4ea2cf4e11"
+checksum = "e4ca605381c017ec7a5fef5e548f1cfaa419ed0f6df6367339300db74c92aa7d"
 dependencies = [
  "serde",
 ]
@@ -1028,9 +1034,9 @@ checksum = "3006df2e7bf21592b4983931164020b02f54eefdc1e35b2f70147858cc1e20ad"
 
 [[package]]
 name = "fastrand"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a407cfaa3385c4ae6b23e84623d48c2798d06e3e6a1878f7f59f17b3f86499"
+checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
 dependencies = [
  "instant",
 ]
@@ -1048,21 +1054,21 @@ dependencies = [
 
 [[package]]
 name = "filetime"
-version = "0.2.18"
+version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b9663d381d07ae25dc88dbdf27df458faa83a9b25336bcac83d5e452b5fc9d3"
+checksum = "8a3de6e8d11b22ff9edc6d916f890800597d60f8b2da1caf2955c274638d6412"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
  "redox_syscall",
- "windows-sys 0.42.0",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
 name = "flate2"
-version = "1.0.24"
+version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f82b0f4c27ad9f8bfd1f3208d882da2b09c301bc1c828fd3a00d0216d2fbbff6"
+checksum = "a8a2db397cb1c8772f31494cb8917e48cd1e64f0fa7efac59fbd741a0a8ce841"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -1110,9 +1116,9 @@ dependencies = [
 
 [[package]]
 name = "fs_extra"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2022715d62ab30faffd124d40b76f4134a550a87792276512b18d63272333394"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "funty"
@@ -1122,9 +1128,9 @@ checksum = "fed34cd105917e91daa4da6b3728c47b068749d6a62c59811f06ed2ac71d9da7"
 
 [[package]]
 name = "futures"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38390104763dc37a5145a53c29c63c1290b5d316d6086ec32c293f6736051bb0"
+checksum = "13e2792b0ff0340399d58445b88fd9770e3489eff258a4cbc1523418f12abf84"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1137,9 +1143,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ba265a92256105f45b719605a571ffe2d1f0fea3807304b522c1d778f79eed"
+checksum = "2e5317663a9089767a1ec00a487df42e0ca174b61b4483213ac24448e4664df5"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1147,15 +1153,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04909a7a7e4633ae6c4a9ab280aeb86da1236243a77b694a49eacd659a4bd3ac"
+checksum = "ec90ff4d0fe1f57d600049061dc6bb68ed03c7d2fbd697274c41805dcb3f8608"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7acc85df6714c176ab5edf386123fafe217be88c0840ec11f199441134a074e2"
+checksum = "e8de0a35a6ab97ec8869e32a2473f4b1324459e14c29275d14b10cb1fd19b50e"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1164,15 +1170,15 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00f5fb52a06bdcadeb54e8d3671f8888a39697dcb0b81b23b55174030427f4eb"
+checksum = "bfb8371b6fb2aeb2d280374607aeabfc99d95c72edfe51692e42d3d7f0d08531"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdfb8ce053d86b91919aad980c220b1fb8401a9394410e1c289ed7e66b61835d"
+checksum = "95a73af87da33b5acf53acfebdc339fe592ecf5357ac7c0a7734ab9d8c876a70"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1181,21 +1187,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39c15cf1a4aa79df40f1bb462fb39676d0ad9e366c2a33b590d7c66f4f81fcf9"
+checksum = "f310820bb3e8cfd46c80db4d7fb8353e15dfff853a127158425f31e0be6c8364"
 
 [[package]]
 name = "futures-task"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ffb393ac5d9a6eaa9d3fdf37ae2776656b706e200c8e16b1bdb227f5198e6ea"
+checksum = "dcf79a1bf610b10f42aea489289c5a2c478a786509693b80cd39c44ccd936366"
 
 [[package]]
 name = "futures-util"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "197676987abd2f9cadff84926f410af1c183608d36641465df73ae8211dc65d6"
+checksum = "9c1d6de3acfef38d2be4b1f543f553131788603495be83da675e180c8d6b7bd1"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1232,9 +1238,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.26.2"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22030e2c5a68ec659fde1e949a745124b48e6fa8b045b7ed5bd1fe4ccc5c4e5d"
+checksum = "ad0a93d233ebf96623465aad4046a8d3aa4da22d4f4beba5388838c8a434bbb4"
 
 [[package]]
 name = "group"
@@ -1262,7 +1268,7 @@ dependencies = [
  "indexmap",
  "slab",
  "tokio",
- "tokio-util 0.7.4",
+ "tokio-util 0.7.7",
  "tracing",
 ]
 
@@ -1278,7 +1284,7 @@ version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3e372db8e5c0d213e0cd0b9be18be2aca3d44cf2fe30a9d46a65581cd454584"
 dependencies = [
- "base64",
+ "base64 0.13.1",
  "bitflags",
  "bytes",
  "headers-core",
@@ -1311,6 +1317,15 @@ name = "hermit-abi"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "hermit-abi"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
 dependencies = [
  "libc",
 ]
@@ -1373,9 +1388,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75f43d41e26995c17e71ee126451dd3941010b0514a81a9d11f3b341debc2399"
+checksum = "bd6effc99afb63425aff9b05836f029929e345a6148a14b7ecd5ab67af944482"
 dependencies = [
  "bytes",
  "fnv",
@@ -1413,9 +1428,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.23"
+version = "0.14.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "034711faac9d2166cb1baf1a2fb0b60b1f277f8492fd72176c17f3515e1abd3c"
+checksum = "5e011372fa0b68db8350aa7a248930ecc7839bf46d8485577d69f117a75f164c"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1484,9 +1499,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.9.1"
+version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
+checksum = "1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399"
 dependencies = [
  "autocfg",
  "hashbrown",
@@ -1504,9 +1519,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.5.1"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f88c5561171189e69df9d98bcf18fd5f9558300f7ea7b801eb8a0fd748bd8745"
+checksum = "30e22bd8629359895450b59ea7a776c850561b96a3b1d31321c1949d9e6c9146"
 
 [[package]]
 name = "itertools"
@@ -1519,9 +1534,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4217ad341ebadf8d8e724e264f13e593e0648f5b3e94b3896a5df283be015ecc"
+checksum = "fad582f4b9e86b6caa621cabeb0963332d92eea04729ab12892c2533951e6440"
 
 [[package]]
 name = "jemalloc-ctl"
@@ -1566,9 +1581,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.60"
+version = "0.3.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49409df3e3bf0856b916e2ceaca09ee28e6871cf7d9ce97a692cacfdb2a25a47"
+checksum = "445dde2150c55e483f3d8416706b97ec8e8237c307e5b7b4b8dd15e6af2a0730"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1599,15 +1614,21 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.137"
+version = "0.2.139"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7fcc620a3bff7cdd7a365be3376c97191aeaccc2a603e600951e452615bf89"
+checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
+
+[[package]]
+name = "libm"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "348108ab3fba42ec82ff6e9564fc4ca0247bdccdc68dd8af9764bbc79c3c8ffb"
 
 [[package]]
 name = "link-cplusplus"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9272ab7b96c9046fbc5bc56c06c117cb639fe2d509df0c421cad82d2915cf369"
+checksum = "ecd207c9c713c34f95a097a5b029ac2ce6010530c7b49d7fea24d977dede04f5"
 dependencies = [
  "cc",
 ]
@@ -1730,23 +1751,23 @@ dependencies = [
 
 [[package]]
 name = "miniz_oxide"
-version = "0.5.4"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96590ba8f175222643a85693f33d26e9c8a015f599c216509b1a6894af675d34"
+checksum = "b275950c28b37e794e8c55d88aeb5e139d0ce23fdbbeda68f8d7174abdf9e8fa"
 dependencies = [
  "adler",
 ]
 
 [[package]]
 name = "mio"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5d732bc30207a6423068df043e3d02e0735b155ad7ce1a6f76fe2baa5b158de"
+checksum = "5b9d9a46eff5b4ff64b45a9e316a6d1e0bc719ef429cbec4dc630684212bfdf9"
 dependencies = [
  "libc",
  "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys 0.42.0",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -1823,9 +1844,9 @@ dependencies = [
 
 [[package]]
 name = "num-complex"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ae39348c8bc5fbd7f40c727a9925f03517afd2ab27d46702108b6a7e5414c19"
+checksum = "02e0d21255c828d6f128a1e41534206671e8c3ea0c62f32291e808dc82cff17d"
 dependencies = [
  "num-traits",
 ]
@@ -1894,15 +1915,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
 name = "num_cpus"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6058e64324c71e02bc2b150e4f3bc8286db6c83092132ffa3f6b1eab0f9def5"
+checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.2.6",
  "libc",
 ]
 
@@ -1917,18 +1939,18 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.29.0"
+version = "0.30.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21158b2c33aa6d4561f1c0a6ea283ca92bc54802a93b263e910746d679a7eb53"
+checksum = "ea86265d3d3dcb6a27fc51bd29a4bf387fae9d2986b823079d4986af253eb439"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "once_cell"
-version = "1.16.0"
+version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860"
+checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
 
 [[package]]
 name = "opaque-debug"
@@ -1938,9 +1960,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
-version = "0.10.42"
+version = "0.10.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12fc0523e3bd51a692c8850d075d74dc062ccf251c0110668cbd921917118a13"
+checksum = "b102428fd03bc5edf97f62620f7298614c45cedf287c271e7ed450bbaf83f2e1"
 dependencies = [
  "bitflags",
  "cfg-if 1.0.0",
@@ -1970,9 +1992,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.77"
+version = "0.9.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b03b84c3b2d099b81f0953422b4d4ad58761589d0229b5506356afca05a3670a"
+checksum = "23bbbf7854cd45b83958ebe919f0e8e516793727652e27fda10a8384cfc790b7"
 dependencies = [
  "autocfg",
  "cc",
@@ -1983,9 +2005,9 @@ dependencies = [
 
 [[package]]
 name = "os_str_bytes"
-version = "6.4.0"
+version = "6.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b5bf27447411e9ee3ff51186bf7a08e16c341efdde93f4d823e8844429bed7e"
+checksum = "9b7820b9daea5457c9f21c69448905d723fbd21136ccf521748f23fd49e723ee"
 
 [[package]]
 name = "parity-wasm"
@@ -2001,7 +2023,7 @@ checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
 dependencies = [
  "instant",
  "lock_api",
- "parking_lot_core 0.8.5",
+ "parking_lot_core 0.8.6",
 ]
 
 [[package]]
@@ -2011,14 +2033,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
 dependencies = [
  "lock_api",
- "parking_lot_core 0.9.4",
+ "parking_lot_core 0.9.7",
 ]
 
 [[package]]
 name = "parking_lot_core"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d76e8e1493bcac0d2766c42737f34458f1c8c50c0d23bcb24ea953affb273216"
+checksum = "60a2cfe6f0ad2bfc16aefa463b497d5c7a5ecd44a23efa72aa342d90177356dc"
 dependencies = [
  "cfg-if 1.0.0",
  "instant",
@@ -2030,15 +2052,15 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.4"
+version = "0.9.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dc9e0dc2adc1c69d09143aff38d3d30c5c3f0df0dad82e6d25547af174ebec0"
+checksum = "9069cbb9f99e3a5083476ccb29ceb1de18b9118cafa53e90c9551235de2b9521"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-sys 0.42.0",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -2053,9 +2075,9 @@ dependencies = [
 
 [[package]]
 name = "paste"
-version = "1.0.9"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1de2e551fb905ac83f73f7aedf2f0cb4a0da7e35efa24a202a936269f1f18e1"
+checksum = "d01a5bd0424d00070b0098dd17ebca6f961a959dead1dbcbbbc1d1cd8d3deeba"
 
 [[package]]
 name = "paste-impl"
@@ -2072,7 +2094,7 @@ version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd56cbd21fea48d0c440b41cd69c589faacade08c992d9a54e471b79d0fd13eb"
 dependencies = [
- "base64",
+ "base64 0.13.1",
  "once_cell",
  "regex",
 ]
@@ -2162,15 +2184,15 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-hack"
-version = "0.5.19"
+version = "0.5.20+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
+checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.47"
+version = "1.0.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ea3d908b0e36316caf9e9e2c4625cdde190a7e6f440d794667ed17a1855e725"
+checksum = "5d727cae5b39d21da60fa540906919ad737832fe0b1c165da3a34d6548c849d6"
 dependencies = [
  "unicode-ident",
 ]
@@ -2192,9 +2214,9 @@ dependencies = [
 
 [[package]]
 name = "proptest"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e0d9cc07f18492d879586c92b485def06bc850da3118075cd45d50e9c95b0e5"
+checksum = "29f1b898011ce9595050a68e60f90bad083ff2987a695a42357134c8381fba70"
 dependencies = [
  "bit-set",
  "bitflags",
@@ -2208,6 +2230,7 @@ dependencies = [
  "regex-syntax",
  "rusty-fork",
  "tempfile",
+ "unarray",
 ]
 
 [[package]]
@@ -2256,9 +2279,9 @@ checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quote"
-version = "1.0.21"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
+checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
 dependencies = [
  "proc-macro2",
 ]
@@ -2364,9 +2387,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.7.0"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e076559ef8e241f2ae3479e36f97bd5741c0330689e217ad51ce2c76808b868a"
+checksum = "48aaa5748ba571fb95cd2c85c09f629215d3a6ece942baa100950af03a34f733"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2399,11 +2422,11 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.11.12"
+version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "431949c384f4e2ae07605ccaa56d1d9d2ecdb5cadd4f9577ccfab29f2e5149fc"
+checksum = "21eed90ec8570952d53b772ecf8f206aa1ec9a3d76b2521c56c42973f2d91ee9"
 dependencies = [
- "base64",
+ "base64 0.21.0",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -2426,11 +2449,12 @@ dependencies = [
  "serde_urlencoded",
  "tokio",
  "tokio-native-tls",
- "tokio-util 0.7.4",
+ "tokio-util 0.7.7",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
  "winreg",
 ]
@@ -2452,7 +2476,7 @@ checksum = "44519172358fd6d58656c86ab8e7fbc9e1490c3e8f14d35ed78ca0dd07403c9f"
 dependencies = [
  "byteorder",
  "num-traits",
- "paste 1.0.9",
+ "paste 1.0.11",
 ]
 
 [[package]]
@@ -2487,7 +2511,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5eebeaeb360c87bfb72e84abdb3447159c0eaececf1bef2aecd65a8be949d1c9"
 dependencies = [
- "base64",
+ "base64 0.13.1",
 ]
 
 [[package]]
@@ -2504,9 +2528,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4501abdff3ae82a1c1b477a17252eb69cee9e66eb915c1abaa4f44d873df9f09"
+checksum = "7b4b9743ed687d4b4bcedf9ff5eaa7398495ae14e61cba0a295704edbc7decde"
 
 [[package]]
 name = "safemem"
@@ -2516,12 +2540,11 @@ checksum = "ef703b7cb59335eae2eb93ceb664c0eb7ea6bf567079d843e09420219668e072"
 
 [[package]]
 name = "schannel"
-version = "0.1.20"
+version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88d6731146462ea25d9244b2ed5fd1d716d25c52e4d54aa4fb0f3c4e9854dbe2"
+checksum = "713cfb06c7059f3588fb8044c0fad1d09e3c01d225e25b9220dbfdcf16dbb1b3"
 dependencies = [
- "lazy_static",
- "windows-sys 0.36.1",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -2563,15 +2586,15 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "scratch"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8132065adcfd6e02db789d9285a0deb2f3fcb04002865ab67d5fb103533898"
+checksum = "ddccb15bcce173023b3fedd9436f882a0739b8dfb45e4f6b6002bee5929f61b2"
 
 [[package]]
 name = "security-framework"
-version = "2.7.0"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bc1bb97804af6631813c55739f771071e0f2ed33ee20b68c86ec505d906356c"
+checksum = "a332be01508d814fed64bf28f798a146d73792121129962fdf335bb3c49a4254"
 dependencies = [
  "bitflags",
  "core-foundation",
@@ -2582,9 +2605,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.6.1"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0160a13a177a45bfb43ce71c01580998474f556ad854dcbca936dd2841a5c556"
+checksum = "31c9bb296072e961fcbd8853511dd39c2d8be2deb1e17c6860b1d30732b323b4"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -2592,15 +2615,15 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.14"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e25dfac463d778e353db5be2449d1cce89bd6fd23c9f1ea21310ce6e5a1b29c4"
+checksum = "58bc9567378fc7690d6b2addae4e60ac2eeea07becb2c64b9f218b53865cba2a"
 
 [[package]]
 name = "serde"
-version = "1.0.147"
+version = "1.0.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d193d69bae983fc11a79df82342761dfbf28a99fc8d203dca4c3c1b590948965"
+checksum = "bb7d1f0d3021d347a83e556fc4683dea2ea09d87bccdf88ff5c12545d89d5efb"
 dependencies = [
  "serde_derive",
 ]
@@ -2616,18 +2639,18 @@ dependencies = [
 
 [[package]]
 name = "serde_bytes"
-version = "0.11.7"
+version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfc50e8183eeeb6178dcb167ae34a8051d63535023ae38b5d8d12beae193d37b"
+checksum = "416bda436f9aab92e02c8e10d49a15ddd339cea90b6e340fe51ed97abb548294"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.147"
+version = "1.0.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f1d362ca8fc9c3e3a7484440752472d68a6caa98f1ab81d99b5dfe517cec852"
+checksum = "af487d118eecd09402d70a5d72551860e788df87b464af30e5ea6a38c75c541e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2647,9 +2670,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.87"
+version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce777b7b150d76b9cf60d28b55f5847135a003f7d7350c6be7a773508ce7d45"
+checksum = "cad406b69c91885b5107daf2c29572f6c8cdb3c66826821e286c533490c0bc76"
 dependencies = [
  "itoa",
  "ryu",
@@ -2658,9 +2681,9 @@ dependencies = [
 
 [[package]]
 name = "serde_repr"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fe39d9fbb0ebf5eb2c7cb7e2a47e4f462fad1379f1166b8ae49ad9eae89a7ca"
+checksum = "9a5ec9fa74a20ebbe5d9ac23dac1fc96ba0ecfe9f50f2843b52e537b10fbcb4e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2681,13 +2704,13 @@ dependencies = [
 
 [[package]]
 name = "sha-1"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "028f48d513f9678cda28f6e4064755b3fbb2af6acd672f2c209b62323f7aea0f"
+checksum = "f5058ada175748e33390e40e872bd0fe59a19f265d0158daa551c5a88a76009c"
 dependencies = [
  "cfg-if 1.0.0",
  "cpufeatures",
- "digest 0.10.5",
+ "digest 0.10.6",
 ]
 
 [[package]]
@@ -2698,7 +2721,7 @@ checksum = "f04293dc80c3993519f2d7f6f511707ee7094fe0c6d3406feb330cdb3540eba3"
 dependencies = [
  "cfg-if 1.0.0",
  "cpufeatures",
- "digest 0.10.5",
+ "digest 0.10.6",
 ]
 
 [[package]]
@@ -2725,9 +2748,9 @@ dependencies = [
 
 [[package]]
 name = "signal-hook"
-version = "0.3.14"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a253b5e89e2698464fc26b545c9edceb338e18a89effeeecfea192c3025be29d"
+checksum = "732768f1176d21d09e076c23a93123d40bba92d50c4058da34d45c8de8e682b9"
 dependencies = [
  "libc",
  "signal-hook-registry",
@@ -2735,9 +2758,9 @@ dependencies = [
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0"
+checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
 dependencies = [
  "libc",
 ]
@@ -2760,14 +2783,14 @@ checksum = "48dfff04aade74dd495b007c831cd6f4e0cee19c344dd9dc0884c0289b70a786"
 dependencies = [
  "log",
  "termcolor",
- "time 0.3.17",
+ "time 0.3.19",
 ]
 
 [[package]]
 name = "slab"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4614a76b2a8be0058caa9dbbaf66d988527d86d003c11a94fbd335d7661edcef"
+checksum = "6528351c9bc8ab22353f9d776db39a20288e8d6c37ef8cfe3317cf875eecfc2d"
 dependencies = [
  "autocfg",
 ]
@@ -2841,9 +2864,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.103"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a864042229133ada95abf3b54fdc62ef5ccabe9515b64717bcb9a1919e59445d"
+checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2923,18 +2946,18 @@ checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
 
 [[package]]
 name = "thiserror"
-version = "1.0.37"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10deb33631e3c9018b9baf9dcbbc4f737320d2b576bac10f6aefa048fa407e3e"
+checksum = "6a9cd18aa97d5c45c6603caea1da6628790b37f7a34b6ca89522331c5180fed0"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.37"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "982d17546b47146b28f7c22e3d08465f6b8903d0ea13c1660d9d84a6e7adcdbb"
+checksum = "1fb327af4685e4d03fa8cbcf1716380da910eeb2bb8be417e7f9fd3fb164f36f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2943,18 +2966,19 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "1.1.4"
+version = "1.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5516c27b78311c50bf42c071425c560ac799b11c30b31f87e3081965fe5e0180"
+checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
 dependencies = [
+ "cfg-if 1.0.0",
  "once_cell",
 ]
 
 [[package]]
 name = "time"
-version = "0.1.44"
+version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
+checksum = "1b797afad3f312d1c66a56d11d0316f916356d11bd158fbc6ca6389ff6bf805a"
 dependencies = [
  "libc",
  "wasi 0.10.0+wasi-snapshot-preview1",
@@ -2963,9 +2987,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.17"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a561bf4617eebd33bca6434b988f39ed798e527f51a1e797d0ee4f61c0a38376"
+checksum = "53250a3b3fed8ff8fd988587d8925d26a83ac3845d9e03b220b37f34c2b8d6c2"
 dependencies = [
  "itoa",
  "libc",
@@ -2983,9 +3007,9 @@ checksum = "2e153e1f1acaef8acc537e68b44906d2db6436e2b35ac2c6b42640fff91f00fd"
 
 [[package]]
 name = "time-macros"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d967f99f534ca7e495c575c62638eebc2898a8c84c119b89e250477bc4ba16b2"
+checksum = "a460aeb8de6dcb0f381e1ee05f1cd56fcf5a5f6eb8187ff3d8f0b11078d38b7c"
 dependencies = [
  "time-core",
 ]
@@ -3001,15 +3025,15 @@ dependencies = [
 
 [[package]]
 name = "tinyvec_macros"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.21.2"
+version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9e03c497dc955702ba729190dc4aac6f2a0ce97f913e5b1b5912fc5039d9099"
+checksum = "c8e00990ebabbe4c14c08aca901caed183ecd5c09562a12c824bb53d3c3fd3af"
 dependencies = [
  "autocfg",
  "bytes",
@@ -3022,14 +3046,14 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "winapi",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "1.8.0"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9724f9a975fb987ef7a3cd9be0350edcbe130698af5b8f7a631e23d42d052484"
+checksum = "d266c00fde287f55d3f1c3e96c500c362a2b8c695076ec180f27918820bc6df8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3038,9 +3062,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-native-tls"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
 dependencies = [
  "native-tls",
  "tokio",
@@ -3075,14 +3099,14 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d660770404473ccd7bc9f8b28494a811bc18542b915c0855c51e8f419d5223ce"
+checksum = "8fb52b74f05dbf495a8fba459fdc331812b96aa086d9eb78101fa0d4569c3313"
 dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
- "tokio-util 0.7.4",
+ "tokio-util 0.7.7",
 ]
 
 [[package]]
@@ -3113,9 +3137,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.4"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bb2e075f03b3d66d8d8785356224ba688d2906a371015e225beeb65ca92c740"
+checksum = "5427d89453009325de0d8f342c9490009f76e999cb7672d77e46267448f7e6b2"
 dependencies = [
  "bytes",
  "futures-core",
@@ -3127,9 +3151,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.5.9"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d82e1a7758622a465f8cee077614c73484dac5b836c02ff6a40d5d1010324d7"
+checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
 dependencies = [
  "serde",
 ]
@@ -3143,7 +3167,7 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
- "tokio-util 0.7.4",
+ "tokio-util 0.7.7",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -3250,9 +3274,9 @@ dependencies = [
 
 [[package]]
 name = "try-lock"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
+checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
 
 [[package]]
 name = "tungstenite"
@@ -3260,7 +3284,7 @@ version = "0.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e27992fd6a8c29ee7eef28fc78349aa244134e10ad447ce3b9f0ac0ed0fa4ce0"
 dependencies = [
- "base64",
+ "base64 0.13.1",
  "byteorder",
  "bytes",
  "http",
@@ -3284,21 +3308,27 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
+checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
 
 [[package]]
 name = "uint"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a45526d29728d135c2900b0d30573fe3ee79fceb12ef534c7bb30e810a91b601"
+checksum = "76f64bba2c53b04fcab63c01a7d7427eadc821e3bc48c34dc9ba29c501164b52"
 dependencies = [
  "byteorder",
  "crunchy",
  "hex",
  "static_assertions",
 ]
+
+[[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicase"
@@ -3311,15 +3341,15 @@ dependencies = [
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.8"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992"
+checksum = "d54675592c1dbefd78cbd98db9bacd89886e1ca50692a0692baefffdeb92dd58"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ceab39d59e4c9499d4e5a8ee0e2735b891bb7308ac83dfb4e80cad195c9f6f3"
+checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
 
 [[package]]
 name = "unicode-normalization"
@@ -3332,9 +3362,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.10.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fdbf052a0783de01e944a6ce7a8cb939e295b1e7be835a1112c3b9a7f047a5a"
+checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
 
 [[package]]
 name = "unicode-width"
@@ -3472,7 +3502,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-tungstenite",
- "tokio-util 0.7.4",
+ "tokio-util 0.7.7",
  "tower-service",
  "tracing",
 ]
@@ -3509,9 +3539,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.83"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaf9f5aceeec8be17c128b2e93e031fb8a4d469bb9c4ae2d7dc1888b26887268"
+checksum = "31f8dcbc21f30d9b8f2ea926ecb58f6b91192c17e9d33594b3df58b2007ca53b"
 dependencies = [
  "cfg-if 1.0.0",
  "wasm-bindgen-macro",
@@ -3519,9 +3549,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.83"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c8ffb332579b0557b52d268b91feab8df3615f265d5270fec2a8c95b17c1142"
+checksum = "95ce90fd5bcc06af55a641a86428ee4229e44e07033963a2290a8e241607ccb9"
 dependencies = [
  "bumpalo",
  "log",
@@ -3534,9 +3564,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.33"
+version = "0.4.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23639446165ca5a5de86ae1d8896b737ae80319560fbaa4c2887b7da6e7ebd7d"
+checksum = "f219e0d211ba40266969f6dbdd90636da12f75bee4fc9d6c23d1260dadb51454"
 dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
@@ -3546,9 +3576,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.83"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "052be0f94026e6cbc75cdefc9bae13fd6052cdcaf532fa6c45e7ae33a1e6c810"
+checksum = "4c21f77c0bedc37fd5dc21f897894a5ca01e7bb159884559461862ae90c0b4c5"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3556,9 +3586,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.83"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bc0c051dc5f23e307b13285f9d75df86bfdf816c5721e573dec1f9b8aa193c"
+checksum = "2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3569,9 +3599,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.83"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c38c045535d93ec4f0b4defec448e4291638ee608530863b1e2ba115d4fff7f"
+checksum = "0046fef7e28c3804e5e38bfa31ea2a0f73905319b677e57ebe37e49358989b5d"
+
+[[package]]
+name = "wasm-streams"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bbae3363c08332cadccd13b67db371814cd214c2524020932f0804b8cf7c078"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
 
 [[package]]
 name = "wasmi"
@@ -3599,9 +3642,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.60"
+version = "0.3.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcda906d8be16e728fd5adc5b729afad4e444e106ab28cd1c7256e54fa61510f"
+checksum = "e33b99f4b23ba3eec1a53ac264e35a755f00e966e0065077d6027c0f575b0b97"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3646,103 +3689,84 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"
-version = "0.36.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea04155a16a59f9eab786fe12a4a450e75cdb175f9e0d80da1e17db09f55b8d2"
-dependencies = [
- "windows_aarch64_msvc 0.36.1",
- "windows_i686_gnu 0.36.1",
- "windows_i686_msvc 0.36.1",
- "windows_x86_64_gnu 0.36.1",
- "windows_x86_64_msvc 0.36.1",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
 dependencies = [
  "windows_aarch64_gnullvm",
- "windows_aarch64_msvc 0.42.0",
- "windows_i686_gnu 0.42.0",
- "windows_i686_msvc 0.42.0",
- "windows_x86_64_gnu 0.42.0",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
  "windows_x86_64_gnullvm",
- "windows_x86_64_msvc 0.42.0",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2522491fbfcd58cc84d47aeb2958948c4b8982e9a2d8a2a35bbaed431390e7"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d2aa71f6f0cbe00ae5167d90ef3cfe66527d6f613ca78ac8024c3ccab9a19e"
+checksum = "8c9864e83243fdec7fc9c5444389dcbbfd258f745e7853198f365e3c4968a608"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.36.1"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd0f252f5a35cac83d6311b2e795981f5ee6e67eb1f9a7f64eb4500fbc4dcdb4"
+checksum = "4c8b1b673ffc16c47a9ff48570a9d85e25d265735c503681332589af6253c6c7"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.36.1"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbeae19f6716841636c28d695375df17562ca208b2b7d0dc47635a50ae6c5de7"
+checksum = "de3887528ad530ba7bdbb1faa8275ec7a1155a45ffa57c37993960277145d640"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.36.1"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84c12f65daa39dd2babe6e442988fc329d6243fdce47d7d2d155b8d874862246"
+checksum = "bf4d1122317eddd6ff351aa852118a2418ad4214e6613a50e0191f7004372605"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.36.1"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf7b1b21b5362cbc318f686150e5bcea75ecedc74dd157d874d754a2ca44b0ed"
+checksum = "c1040f221285e17ebccbc2591ffdc2d44ee1f9186324dd3e84e99ac68d699c45"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09d525d2ba30eeb3297665bd434a54297e4170c7f1a44cad4ef58095b4cd2028"
+checksum = "628bfdf232daa22b0d64fdb62b09fcc36bb01f05a3939e20ab73aaf9470d0463"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.36.1"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f40009d85759725a34da6d89a94e63d7bdc50a862acf0dbc7c8e488f1edcb6f5"
+checksum = "447660ad36a13288b1db4d4248e857b510e8c3a225c822ba4fb748c0aafecffd"
 
 [[package]]
 name = "winreg"
@@ -3779,9 +3803,9 @@ dependencies = [
 
 [[package]]
 name = "zeroize_derive"
-version = "1.3.2"
+version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f8f187641dad4f680d25c4bfc4225b418165984179f26ca76ec4fb6441d3a17"
+checksum = "44bf07cb3e50ea2003396695d58bf46bc9887a1f362260446fad6bc4e79bd36c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3810,10 +3834,11 @@ dependencies = [
 
 [[package]]
 name = "zstd-sys"
-version = "2.0.1+zstd.1.5.2"
+version = "2.0.7+zstd.1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fd07cbbc53846d9145dbffdf6dd09a7a0aa52be46741825f5c97bdd4f73f12b"
+checksum = "94509c3ba2fe55294d752b79842c530ccfab760192521df74a081a78d2b3c7f5"
 dependencies = [
  "cc",
  "libc",
+ "pkg-config",
 ]

--- a/src/common/db.rs
+++ b/src/common/db.rs
@@ -72,12 +72,12 @@ pub enum Error {
 impl Display for Error {
     fn fmt(&self, f: &mut Formatter<'_>) -> FormatterResult {
         match self {
-            Self::Database(e) => write!(f, "Error operating the database: {}", e),
-            Self::Parsing(idx, inner) => write!(f, "Error parsing element {}: {}", idx, inner),
+            Self::Database(e) => write!(f, "Error operating the database: {e}"),
+            Self::Parsing(idx, inner) => write!(f, "Error parsing element {idx}: {inner}"),
             Self::Accumulated(accumulated_errors) => {
                 writeln!(f, "Errors caught:")?;
                 for error in accumulated_errors {
-                    writeln!(f, "{}", error)?;
+                    writeln!(f, "{error}")?;
                 }
                 Ok(())
             }

--- a/src/common/db.rs
+++ b/src/common/db.rs
@@ -40,6 +40,7 @@ use thiserror::Error;
 use casper_types::bytesrepr::Error as BytesreprError;
 
 pub const STORAGE_FILE_NAME: &str = "storage.lmdb";
+pub const TRIE_STORE_FILE_NAME: &str = "data.lmdb";
 const ENTRY_LOG_INTERVAL: usize = 100_000;
 const MAX_DB_READERS: u32 = 100;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,7 +10,8 @@ use clap::{crate_description, crate_version, Arg, Command};
 use log::error;
 
 use subcommands::{
-    archive, check, execution_results_summary, latest_block_summary, trie_compact, unsparse, Error,
+    archive, check, execution_results_summary, extract_slice, latest_block_summary, trie_compact,
+    unsparse, Error,
 };
 
 const LOGGING: &str = "logging";
@@ -19,6 +20,7 @@ enum DisplayOrder {
     Archive,
     Check,
     ExecutionResults,
+    ExtractSlice,
     LatestBlock,
     TrieCompact,
     Unsparse,
@@ -34,6 +36,7 @@ fn cli() -> Command<'static> {
         .subcommand(execution_results_summary::command(
             DisplayOrder::ExecutionResults as usize,
         ))
+        .subcommand(extract_slice::command(DisplayOrder::ExtractSlice as usize))
         .subcommand(latest_block_summary::command(
             DisplayOrder::LatestBlock as usize,
         ))
@@ -80,6 +83,7 @@ fn main() {
         execution_results_summary::COMMAND_NAME => {
             execution_results_summary::run(matches).map_err(Error::from)
         }
+        extract_slice::COMMAND_NAME => extract_slice::run(matches).map_err(Error::from),
         latest_block_summary::COMMAND_NAME => {
             latest_block_summary::run(matches).map_err(Error::from)
         }

--- a/src/subcommands.rs
+++ b/src/subcommands.rs
@@ -1,6 +1,7 @@
 pub mod archive;
 pub mod check;
 pub mod execution_results_summary;
+pub mod extract_slice;
 pub mod latest_block_summary;
 pub mod trie_compact;
 pub mod unsparse;
@@ -10,6 +11,7 @@ use thiserror::Error as ThisError;
 use archive::{CreateError, UnpackError};
 use check::Error as CheckError;
 use execution_results_summary::Error as ExecutionResultsSummaryError;
+use extract_slice::Error as ExtractSliceError;
 use latest_block_summary::Error as LatestBlockSummaryError;
 use trie_compact::Error as TrieCompactError;
 use unsparse::Error as UnsparseError;
@@ -24,6 +26,8 @@ pub enum Error {
     Check(#[from] CheckError),
     #[error("Execution results summary command failed: {0}")]
     ExecutionResultsSummary(#[from] ExecutionResultsSummaryError),
+    #[error("Extract slice command failed: {0}")]
+    ExtractSlice(#[from] ExtractSliceError),
     #[error("Latest block summary command failed: {0}")]
     LatestBlockSummary(#[from] LatestBlockSummaryError),
     #[error("Trie compact failed: {0}")]

--- a/src/subcommands/archive/create/tests.rs
+++ b/src/subcommands/archive/create/tests.rs
@@ -27,7 +27,7 @@ fn create_mock_src_dir() -> (TempDir, TestPayloads) {
     let mut payloads = [[0u8; TEST_FILE_SIZE]; NUM_TEST_FILES];
     for (idx, payload) in payloads.iter_mut().enumerate().take(NUM_TEST_FILES) {
         rng.fill_bytes(payload);
-        fs::write(src_dir.path().join(&format!("file_{}", idx)), &payload).unwrap();
+        fs::write(src_dir.path().join(&format!("file_{idx}")), &payload).unwrap();
     }
     (src_dir, TestPayloads { payloads })
 }
@@ -54,9 +54,9 @@ fn archive_create_roundtrip() {
     // Unpack and then delete the archive.
     unpack_mock_archive(&archive_path, &out_dir);
     for idx in 0..NUM_TEST_FILES {
-        let contents = fs::read(out_dir.path().join(&format!("file_{}", idx))).unwrap();
+        let contents = fs::read(out_dir.path().join(&format!("file_{idx}"))).unwrap();
         if contents != test_payloads.payloads[idx] {
-            panic!("Contents of file {} are different from the original", idx);
+            panic!("Contents of file {idx} are different from the original");
         }
     }
 }
@@ -79,9 +79,9 @@ fn archive_create_overwrite() {
     // Unpack and then delete the archive.
     unpack_mock_archive(&archive_path, &out_dir);
     for idx in 0..NUM_TEST_FILES {
-        let contents = fs::read(out_dir.path().join(&format!("file_{}", idx))).unwrap();
+        let contents = fs::read(out_dir.path().join(&format!("file_{idx}"))).unwrap();
         if contents != test_payloads.payloads[idx] {
-            panic!("Contents of file {} are different from the original", idx);
+            panic!("Contents of file {idx} are different from the original");
         }
     }
 }

--- a/src/subcommands/archive/tar_utils.rs
+++ b/src/subcommands/archive/tar_utils.rs
@@ -63,7 +63,7 @@ mod tests {
 
         for idx in 0..num_files {
             let mut file = NamedTempFile::new_in(src_dir.path()).unwrap();
-            file.write_all(format!("test file {}", idx).as_bytes())
+            file.write_all(format!("test file {idx}").as_bytes())
                 .unwrap();
             test_files.push(file);
         }
@@ -86,7 +86,7 @@ mod tests {
         for (idx, file) in test_files.iter().enumerate().take(num_files) {
             let path = dst_dir.path().join(file.path().file_name().unwrap());
             let contents = fs::read_to_string(&path).unwrap();
-            assert_eq!(contents, format!("test file {}", idx));
+            assert_eq!(contents, format!("test file {idx}"));
         }
     }
 }

--- a/src/subcommands/archive/unpack.rs
+++ b/src/subcommands/archive/unpack.rs
@@ -136,7 +136,7 @@ pub fn run(matches: &ArgMatches) -> Result<(), Error> {
             matches
                 .value_of(FILE)
                 .map(|path| Input::File(path.into()))
-                .unwrap_or_else(|| panic!("Should have one of {} or {}", FILE, URL))
+                .unwrap_or_else(|| panic!("Should have one of {FILE} or {URL}"))
         });
     let dest = matches.value_of(OUTPUT).unwrap();
     unpack(input, dest)

--- a/src/subcommands/archive/unpack/tests.rs
+++ b/src/subcommands/archive/unpack/tests.rs
@@ -77,7 +77,7 @@ fn zstd_decode_roundtrip() {
 
     // Write the encoded contents to a file as well.
     let encoded_path = tmp_dir.path().join("encoded");
-    fs::write(&encoded_path, &encoded).unwrap();
+    fs::write(encoded_path, &encoded).unwrap();
 
     // Decode the response with the zstd streaming function.
     let mut decoder = zstd_utils::zstd_decode_stream(encoded.as_slice()).unwrap();

--- a/src/subcommands/check.rs
+++ b/src/subcommands/check.rs
@@ -94,7 +94,7 @@ pub fn run(matches: &ArgMatches) -> Result<(), Error> {
         .value_of(START_AT)
         .expect("should have a default")
         .parse()
-        .unwrap_or_else(|_| panic!("Value of \"--{}\" must be an integer.", START_AT));
+        .unwrap_or_else(|_| panic!("Value of \"--{START_AT}\" must be an integer."));
 
     check_db(path, failfast, specific, start_at)
 }
@@ -106,7 +106,7 @@ fn check_db<P: AsRef<Path>>(
     start_at: usize,
 ) -> Result<(), Error> {
     let storage_path = path.as_ref().join(STORAGE_FILE_NAME);
-    let env = db_env(&storage_path)
+    let env = db_env(storage_path)
         .map_err(|lmdb_err| Error::Path(path.as_ref().to_path_buf(), lmdb_err))?;
     if let Some(db_name) = specific {
         match db_name.trim() {

--- a/src/subcommands/execution_results_summary.rs
+++ b/src/subcommands/execution_results_summary.rs
@@ -1,4 +1,4 @@
-mod block_body;
+pub(crate) mod block_body;
 mod read_db;
 mod summary;
 #[cfg(test)]

--- a/src/subcommands/execution_results_summary/read_db.rs
+++ b/src/subcommands/execution_results_summary/read_db.rs
@@ -135,7 +135,7 @@ pub fn execution_results_summary<P1: AsRef<Path>, P2: AsRef<Path>>(
     overwrite: bool,
 ) -> Result<(), Error> {
     let storage_path = db_path.as_ref().join(STORAGE_FILE_NAME);
-    let env = db::db_env(&storage_path)?;
+    let env = db::db_env(storage_path)?;
     let mut log_progress = false;
     // Validate the output file early so that, in case this fails
     // we don't unnecessarily read the whole database.

--- a/src/subcommands/execution_results_summary/tests.rs
+++ b/src/subcommands/execution_results_summary/tests.rs
@@ -356,7 +356,7 @@ fn execution_results_summary_invalid_key_should_fail() {
         false,
     ) {
         Err(Error::InvalidKey(idx)) => assert_eq!(idx, 0),
-        Err(error) => panic!("Got unexpected error: {:?}", error),
+        Err(error) => panic!("Got unexpected error: {error:?}"),
         Ok(_) => panic!("Command unexpectedly succeeded"),
     }
 }
@@ -411,7 +411,7 @@ fn execution_results_summary_parsing_should_fail() {
             assert_eq!(hash, block_hash);
             assert_eq!(db_name, DeployMetadataDatabase::db_name());
         }
-        Err(error) => panic!("Got unexpected error: {:?}", error),
+        Err(error) => panic!("Got unexpected error: {error:?}"),
         Ok(_) => panic!("Command unexpectedly succeeded"),
     }
 }
@@ -427,7 +427,7 @@ fn execution_results_summary_bogus_db_should_fail() {
         false,
     ) {
         Err(Error::Database(_)) => { /* expected result */ }
-        Err(error) => panic!("Got unexpected error: {:?}", error),
+        Err(error) => panic!("Got unexpected error: {error:?}"),
         Ok(_) => panic!("Command unexpectedly succeeded"),
     }
 }
@@ -450,7 +450,7 @@ fn execution_results_summary_existing_output_should_fail() {
         false,
     ) {
         Err(Error::Output(_)) => { /* expected result */ }
-        Err(error) => panic!("Got unexpected error: {:?}", error),
+        Err(error) => panic!("Got unexpected error: {error:?}"),
         Ok(_) => panic!("Command unexpectedly succeeded"),
     }
 }

--- a/src/subcommands/execution_results_summary/tests.rs
+++ b/src/subcommands/execution_results_summary/tests.rs
@@ -4,9 +4,8 @@ use std::{
     slice,
 };
 
-use casper_hashing::Digest;
-use casper_node::types::{BlockHash, DeployHash, DeployMetadata};
-use casper_types::{bytesrepr::ToBytes, ExecutionEffect, ExecutionResult};
+use casper_node::types::{BlockHash, DeployHash};
+use casper_types::bytesrepr::ToBytes;
 use lmdb::{Transaction, WriteFlags};
 use once_cell::sync::Lazy;
 use rand::Rng;
@@ -23,40 +22,13 @@ use crate::{
         },
         Error,
     },
-    test_utils::{LmdbTestFixture, MockBlockHeader},
+    test_utils::{
+        mock_block_header, mock_deploy_hash, mock_deploy_metadata, success_execution_result,
+        LmdbTestFixture, MockBlockHeader,
+    },
 };
 
 static OUT_DIR: Lazy<TempDir> = Lazy::new(|| tempfile::tempdir().unwrap());
-
-fn mock_deploy_hash(idx: u8) -> DeployHash {
-    DeployHash::new([idx; 32].into())
-}
-
-fn mock_block_header(idx: u8) -> (BlockHash, MockBlockHeader) {
-    let mut block_header = MockBlockHeader::default();
-    let block_hash_digest: Digest = [idx; Digest::LENGTH].into();
-    let block_hash: BlockHash = block_hash_digest.into();
-    block_header.body_hash = [idx; Digest::LENGTH].into();
-    (block_hash, block_header)
-}
-
-fn mock_deploy_metadata(block_hashes: &[BlockHash]) -> DeployMetadata {
-    let mut deploy_metadata = DeployMetadata::default();
-    for block_hash in block_hashes {
-        deploy_metadata
-            .execution_results
-            .insert(*block_hash, success_execution_result());
-    }
-    deploy_metadata
-}
-
-fn success_execution_result() -> ExecutionResult {
-    ExecutionResult::Success {
-        effect: ExecutionEffect::default(),
-        transfers: vec![],
-        cost: 100.into(),
-    }
-}
 
 #[test]
 fn check_chunk_count_after_partition() {

--- a/src/subcommands/extract_slice.rs
+++ b/src/subcommands/extract_slice.rs
@@ -82,7 +82,7 @@ pub fn command(display_order: usize) -> Command<'static> {
             Arg::new(BLOCK_HASH)
                 .display_order(DisplayOrder::BlockHash as usize)
                 .short('b')
-                .long(OUTPUT)
+                .long(BLOCK_HASH)
                 .takes_value(true)
                 .value_name("BLOCK_HASH")
                 .help("Hash of the block which defines the slice."),

--- a/src/subcommands/extract_slice.rs
+++ b/src/subcommands/extract_slice.rs
@@ -1,0 +1,106 @@
+mod db_helpers;
+mod extract;
+mod global_state;
+mod storage;
+#[cfg(test)]
+mod tests;
+
+use std::{io::Error as IoError, path::Path};
+
+use bincode::Error as BincodeError;
+use casper_hashing::Digest;
+use casper_node::types::BlockHash;
+use clap::{Arg, ArgMatches, Command};
+use lmdb::Error as LmdbError;
+use thiserror::Error as ThisError;
+
+pub const COMMAND_NAME: &str = "extract-slice";
+const BLOCK_HASH: &str = "block-hash";
+const OUTPUT: &str = "output";
+const SOURCE_DB_PATH: &str = "source-db-path";
+
+/// Errors encountered when running the `extract-slice` subcommand.
+#[derive(Debug, ThisError)]
+pub enum Error {
+    #[error("Error (de)serializing items with bincode: {0}")]
+    Bincode(#[from] BincodeError),
+    #[error("Error creating the destination execution engine: {0}")]
+    CreateExecutionEngine(anyhow::Error),
+    #[error("Error operating the database: {0}")]
+    Database(#[from] LmdbError),
+    #[error("Error loading the source execution engine: {0}")]
+    LoadExecutionEngine(anyhow::Error),
+    #[error("Error writing output: {0}")]
+    Output(#[from] IoError),
+    #[error("Error parsing element for block hash {0} in {1} DB: {2}")]
+    Parsing(BlockHash, String, BincodeError),
+    #[error("Error transferring state root: {0}")]
+    StateRootTransfer(anyhow::Error),
+}
+
+enum DisplayOrder {
+    SourceDbPath,
+    Output,
+    BlockHash,
+}
+
+pub fn command(display_order: usize) -> Command<'static> {
+    Command::new(COMMAND_NAME)
+        .display_order(display_order)
+        .about(
+            "Reads all data for a given block hash (block, deploys, execution \
+                results, global state) from a storage directory and stores \
+                them to a new directory in two LMDB files",
+        )
+        .arg(
+            Arg::new(SOURCE_DB_PATH)
+                .display_order(DisplayOrder::SourceDbPath as usize)
+                .required(true)
+                .short('d')
+                .long(SOURCE_DB_PATH)
+                .takes_value(true)
+                .value_name("SOURCE_DB_PATH")
+                .help(
+                    "Path of the directory with the `storage.lmdb` and \
+                `data.lmdb` files.",
+                ),
+        )
+        .arg(
+            Arg::new(OUTPUT)
+                .display_order(DisplayOrder::Output as usize)
+                .short('o')
+                .long(OUTPUT)
+                .takes_value(true)
+                .value_name("OUTPUT_DB_PATH")
+                .help(
+                    "Path of the directory where the program will output the \
+                    two newly created `storage.lmdb` and `data.lmdb` files. \
+                    The directory must not exist when running this command.",
+                ),
+        )
+        .arg(
+            Arg::new(BLOCK_HASH)
+                .display_order(DisplayOrder::BlockHash as usize)
+                .short('b')
+                .long(OUTPUT)
+                .takes_value(true)
+                .value_name("BLOCK_HASH")
+                .help("Hash of the block which defines the slice."),
+        )
+}
+
+pub fn run(matches: &ArgMatches) -> Result<(), Error> {
+    let path = Path::new(
+        matches
+            .value_of(SOURCE_DB_PATH)
+            .expect("should have db-path arg"),
+    );
+    let output = Path::new(matches.value_of(OUTPUT).expect("should have output arg"));
+    let block_hash_string = matches
+        .value_of(BLOCK_HASH)
+        .expect("should have block-hash arg");
+    let block_hash: BlockHash = Digest::from_hex(block_hash_string)
+        .expect("should parse block hash to hex format")
+        .into();
+    extract::extract_slice(path, output, block_hash)
+}

--- a/src/subcommands/extract_slice/db_helpers.rs
+++ b/src/subcommands/extract_slice/db_helpers.rs
@@ -1,0 +1,39 @@
+use std::result::Result;
+
+use lmdb::{Error as LmdbError, RoTransaction, RwTransaction, Transaction, WriteFlags};
+
+/// Reads the value under a key in a database using the given LMDB transaction.
+pub(crate) fn read_from_db<K: AsRef<[u8]>>(
+    txn: &mut RoTransaction,
+    db_name: &str,
+    key: &K,
+) -> Result<Vec<u8>, LmdbError> {
+    let db = unsafe { txn.open_db(Some(db_name))? };
+    let value = txn.get(db, key)?.to_vec();
+    Ok(value)
+}
+
+/// Writes a key-value pair in a database using the given LMDB transaction.
+pub(crate) fn write_to_db<K: AsRef<[u8]>, V: AsRef<[u8]>>(
+    txn: &mut RwTransaction,
+    db_name: &str,
+    key: &K,
+    value: &V,
+) -> Result<(), LmdbError> {
+    let db = unsafe { txn.open_db(Some(db_name))? };
+    txn.put(db, key, value, WriteFlags::empty())?;
+    Ok(())
+}
+
+/// Copies the value under a key from the source database to the destination
+/// database and returns the raw value bytes.
+pub(crate) fn transfer_to_new_db<K: AsRef<[u8]>>(
+    source_txn: &mut RoTransaction,
+    destination_txn: &mut RwTransaction,
+    db_name: &str,
+    key: &K,
+) -> Result<Vec<u8>, LmdbError> {
+    let value = read_from_db(source_txn, db_name, key)?;
+    write_to_db(destination_txn, db_name, key, &value)?;
+    Ok(value)
+}

--- a/src/subcommands/extract_slice/extract.rs
+++ b/src/subcommands/extract_slice/extract.rs
@@ -1,0 +1,16 @@
+use std::path::Path;
+
+use casper_node::types::BlockHash;
+
+use super::{global_state, storage, Error};
+
+pub fn extract_slice<P1: AsRef<Path>, P2: AsRef<Path>>(
+    db_path: P1,
+    output: P2,
+    block_hash: BlockHash,
+) -> Result<(), Error> {
+    storage::create_output_db(&output)?;
+    let state_root_hash = storage::transfer_block_info(&db_path, &output, block_hash)?;
+    global_state::transfer_global_state(&db_path, &output, state_root_hash)?;
+    Ok(())
+}

--- a/src/subcommands/extract_slice/global_state.rs
+++ b/src/subcommands/extract_slice/global_state.rs
@@ -1,6 +1,7 @@
 use std::{path::Path, result::Result};
 
 use casper_hashing::Digest;
+use log::info;
 
 use crate::subcommands::trie_compact::{
     copy_state_root, create_execution_engine, load_execution_engine, DEFAULT_MAX_DB_SIZE,
@@ -25,6 +26,7 @@ pub(crate) fn transfer_global_state<P1: AsRef<Path>, P2: AsRef<Path>>(
     // Create the destination trie store.
     let (destination_state, _env) = create_execution_engine(destination, max_db_size, true)
         .map_err(Error::CreateExecutionEngine)?;
+    info!("Starting transfer process for state root hash {state_root_hash}");
     // Copy the state root along with missing descendants over to the new trie
     // store.
     copy_state_root(state_root_hash, &source_state, &destination_state)

--- a/src/subcommands/extract_slice/global_state.rs
+++ b/src/subcommands/extract_slice/global_state.rs
@@ -18,8 +18,6 @@ pub(crate) fn transfer_global_state<P1: AsRef<Path>, P2: AsRef<Path>>(
     let max_db_size = DEFAULT_MAX_DB_SIZE
         .parse()
         .expect("should be able to parse max db size");
-    // let source_path = source.as_ref().join(TRIE_STORE_FILE_NAME);
-    // let destination_path = destination.as_ref().join(TRIE_STORE_FILE_NAME);
 
     // Load the source trie store.
     let (source_state, _env) = load_execution_engine(source, max_db_size, Digest::default(), true)

--- a/src/subcommands/extract_slice/global_state.rs
+++ b/src/subcommands/extract_slice/global_state.rs
@@ -1,0 +1,37 @@
+use std::{path::Path, result::Result};
+
+use casper_hashing::Digest;
+
+use crate::subcommands::trie_compact::{
+    copy_state_root, create_execution_engine, load_execution_engine, DEFAULT_MAX_DB_SIZE,
+};
+
+use super::Error;
+
+/// Transfers the global state under a state root hash from a trie store to a
+/// new one.
+pub(crate) fn transfer_global_state<P1: AsRef<Path>, P2: AsRef<Path>>(
+    source: P1,
+    destination: P2,
+    state_root_hash: Digest,
+) -> Result<(), Error> {
+    let max_db_size = DEFAULT_MAX_DB_SIZE
+        .parse()
+        .expect("should be able to parse max db size");
+    // let source_path = source.as_ref().join(TRIE_STORE_FILE_NAME);
+    // let destination_path = destination.as_ref().join(TRIE_STORE_FILE_NAME);
+
+    // Load the source trie store.
+    let (source_state, _env) = load_execution_engine(source, max_db_size, Digest::default(), true)
+        .map_err(Error::LoadExecutionEngine)?;
+    // Create the destination trie store.
+    let (destination_state, _env) = create_execution_engine(destination, max_db_size, true)
+        .map_err(Error::CreateExecutionEngine)?;
+    // Copy the state root along with missing descendants over to the new trie
+    // store.
+    copy_state_root(state_root_hash, &source_state, &destination_state)
+        .map_err(Error::StateRootTransfer)?;
+    destination_state.flush_environment()?;
+
+    Ok(())
+}

--- a/src/subcommands/extract_slice/storage.rs
+++ b/src/subcommands/extract_slice/storage.rs
@@ -1,0 +1,130 @@
+use std::{fs, io::ErrorKind, path::Path, result::Result};
+
+use casper_hashing::Digest;
+use lmdb::{DatabaseFlags, Error as LmdbError, Transaction};
+
+use casper_node::types::{BlockHash, BlockHeader, DeployMetadata};
+
+use crate::{
+    common::db::{
+        self, BlockBodyDatabase, BlockHeaderDatabase, Database, DeployDatabase,
+        DeployMetadataDatabase, TransferDatabase, STORAGE_FILE_NAME,
+    },
+    subcommands::execution_results_summary::block_body::BlockBody,
+};
+
+use super::{db_helpers, Error};
+
+pub(crate) fn create_output_db<P: AsRef<Path>>(output_path: P) -> Result<(), Error> {
+    if output_path.as_ref().exists() {
+        return Err(Error::Output(ErrorKind::AlreadyExists.into()));
+    }
+    fs::create_dir_all(&output_path)?;
+
+    let storage_path = output_path.as_ref().join(STORAGE_FILE_NAME);
+    let storage_env = db::db_env(storage_path)?;
+
+    storage_env.create_db(Some(BlockHeaderDatabase::db_name()), DatabaseFlags::empty())?;
+    storage_env.create_db(Some(BlockBodyDatabase::db_name()), DatabaseFlags::empty())?;
+    storage_env.create_db(Some(DeployDatabase::db_name()), DatabaseFlags::empty())?;
+    storage_env.create_db(Some(TransferDatabase::db_name()), DatabaseFlags::empty())?;
+    storage_env.create_db(
+        Some(DeployMetadataDatabase::db_name()),
+        DatabaseFlags::empty(),
+    )?;
+
+    Ok(())
+}
+
+/// Given a block hash, reads the information related to the associated block
+/// (block header, block body, deploys, transfers, execution results) and
+/// copies them over to a new database. Returns the state root hash associated
+/// with the block.
+pub(crate) fn transfer_block_info<P1: AsRef<Path>, P2: AsRef<Path>>(
+    source: P1,
+    destination: P2,
+    block_hash: BlockHash,
+) -> Result<Digest, Error> {
+    let source_path = source.as_ref().join(STORAGE_FILE_NAME);
+    let source_env = db::db_env(&source_path)?;
+    let destination_path = destination.as_ref().join(STORAGE_FILE_NAME);
+    let destination_env = db::db_env(&destination_path)?;
+
+    let mut source_txn = source_env.begin_ro_txn()?;
+    let mut destination_txn = destination_env.begin_rw_txn()?;
+
+    // Read the block header associated with the given block hash.
+    let block_header_bytes = db_helpers::transfer_to_new_db(
+        &mut source_txn,
+        &mut destination_txn,
+        BlockHeaderDatabase::db_name(),
+        &block_hash,
+    )?;
+    let block_header: BlockHeader = bincode::deserialize(&block_header_bytes)?;
+
+    // Read the block body associated with the previously read block header.
+    let block_body_bytes = db_helpers::transfer_to_new_db(
+        &mut source_txn,
+        &mut destination_txn,
+        BlockBodyDatabase::db_name(),
+        block_header.body_hash(),
+    )?;
+    let block_body: BlockBody = bincode::deserialize(&block_body_bytes)?;
+
+    // Attempt to copy over all entries in the transfer database for the given
+    // block hash. If we have no entry under the block hash, we move on.
+    match db_helpers::transfer_to_new_db(
+        &mut source_txn,
+        &mut destination_txn,
+        TransferDatabase::db_name(),
+        &block_hash,
+    ) {
+        Ok(_) | Err(LmdbError::NotFound) => {}
+        Err(lmdb_error) => return Err(Error::Database(lmdb_error)),
+    }
+
+    // Copy over all the deploys in this block and construct the execution
+    // results to be stored in the new database.
+    let deploy_metadata_db =
+        unsafe { source_txn.open_db(Some(DeployMetadataDatabase::db_name()))? };
+    for deploy_hash in block_body.deploy_hashes() {
+        // Copy the deploy to the new database.
+        db_helpers::transfer_to_new_db(
+            &mut source_txn,
+            &mut destination_txn,
+            DeployDatabase::db_name(),
+            deploy_hash,
+        )?;
+
+        // Get this deploy's metadata.
+        let metadata_raw = source_txn.get(deploy_metadata_db, &deploy_hash)?;
+        let mut metadata: DeployMetadata =
+            bincode::deserialize(metadata_raw).map_err(|bincode_err| {
+                Error::Parsing(
+                    block_hash,
+                    DeployMetadataDatabase::db_name().to_string(),
+                    bincode_err,
+                )
+            })?;
+        // Extract the execution result of this deploy for this block.
+        if let Some(execution_result) = metadata.execution_results.remove(&block_hash) {
+            // Construct the metadata to be stored using only the relevant
+            // execution results.
+            let mut new_metadata = DeployMetadata::default();
+            new_metadata
+                .execution_results
+                .insert(block_hash, execution_result.clone());
+            let serialized_new_metadata = bincode::serialize(&new_metadata)?;
+            db_helpers::write_to_db(
+                &mut destination_txn,
+                DeployMetadataDatabase::db_name(),
+                deploy_hash,
+                &serialized_new_metadata,
+            )?;
+        }
+    }
+    // Commit the transactions.
+    source_txn.commit()?;
+    destination_txn.commit()?;
+    Ok(*block_header.state_root_hash())
+}

--- a/src/subcommands/extract_slice/tests.rs
+++ b/src/subcommands/extract_slice/tests.rs
@@ -1,0 +1,502 @@
+use std::slice;
+
+use casper_execution_engine::storage::{
+    store::StoreExt,
+    transaction_source::{lmdb::LmdbEnvironment, TransactionSource},
+    trie::Trie,
+    trie_store::lmdb::LmdbTrieStore,
+};
+use casper_hashing::Digest;
+use casper_node::types::{BlockHash, DeployHash, DeployMetadata};
+use casper_types::bytesrepr::{Bytes, ToBytes};
+use lmdb::{DatabaseFlags, Error as LmdbError, Transaction, WriteFlags};
+
+use crate::{
+    common::db::{
+        BlockBodyDatabase, BlockHeaderDatabase, Database, DeployDatabase, DeployMetadataDatabase,
+        TransferDatabase, STORAGE_FILE_NAME,
+    },
+    subcommands::{
+        execution_results_summary::block_body::BlockBody,
+        extract_slice::{db_helpers, global_state, storage},
+        trie_compact::{
+            create_execution_engine, load_execution_engine, tests::create_data, DEFAULT_MAX_DB_SIZE,
+        },
+    },
+    test_utils::{
+        mock_block_header, mock_deploy_hash, mock_deploy_metadata, LmdbTestFixture, MockBlockHeader,
+    },
+};
+
+#[test]
+fn transfer_data_between_dbs() {
+    const DATA_COUNT: usize = 4;
+    const MOCK_DB_NAME: &str = "mock_data";
+
+    let source_fixture = LmdbTestFixture::new(vec![MOCK_DB_NAME], Some(STORAGE_FILE_NAME));
+
+    let deploy_hashes: Vec<DeployHash> = (0..DATA_COUNT as u8).map(mock_deploy_hash).collect();
+
+    {
+        let env = &source_fixture.env;
+        // Insert the 3 blocks into the database.
+        if let Ok(mut txn) = env.begin_rw_txn() {
+            for (i, deploy_hash) in deploy_hashes.iter().enumerate().take(DATA_COUNT) {
+                txn.put(
+                    *source_fixture.db(Some(MOCK_DB_NAME)).unwrap(),
+                    &i.to_le_bytes(),
+                    &bincode::serialize(deploy_hash).unwrap(),
+                    WriteFlags::empty(),
+                )
+                .unwrap();
+            }
+            txn.commit().unwrap();
+        };
+    }
+
+    let destination_fixture = LmdbTestFixture::new(vec![MOCK_DB_NAME], Some(STORAGE_FILE_NAME));
+
+    {
+        let mut source_txn = source_fixture.env.begin_ro_txn().unwrap();
+        assert_eq!(
+            db_helpers::read_from_db(&mut source_txn, MOCK_DB_NAME, &0usize.to_le_bytes()).unwrap(),
+            bincode::serialize(&deploy_hashes[0]).unwrap()
+        );
+        assert_eq!(
+            db_helpers::read_from_db(&mut source_txn, MOCK_DB_NAME, &DATA_COUNT.to_le_bytes())
+                .unwrap_err(),
+            LmdbError::NotFound
+        );
+        source_txn.commit().unwrap();
+    }
+
+    {
+        let mut destination_txn = destination_fixture.env.begin_rw_txn().unwrap();
+        let serialized_deploy_hash = bincode::serialize(&deploy_hashes[1]).unwrap();
+        assert!(db_helpers::write_to_db(
+            &mut destination_txn,
+            MOCK_DB_NAME,
+            &1usize.to_le_bytes(),
+            &serialized_deploy_hash
+        )
+        .is_ok());
+        destination_txn.commit().unwrap();
+    }
+
+    {
+        let mut source_txn = source_fixture.env.begin_ro_txn().unwrap();
+        let mut destination_txn = destination_fixture.env.begin_rw_txn().unwrap();
+        let serialized_deploy_hash = bincode::serialize(&deploy_hashes[2]).unwrap();
+        let copied_bytes = db_helpers::transfer_to_new_db(
+            &mut source_txn,
+            &mut destination_txn,
+            MOCK_DB_NAME,
+            &2usize.to_le_bytes(),
+        )
+        .unwrap();
+        assert_eq!(serialized_deploy_hash, copied_bytes);
+        assert_eq!(
+            db_helpers::transfer_to_new_db(
+                &mut source_txn,
+                &mut destination_txn,
+                MOCK_DB_NAME,
+                &DATA_COUNT.to_le_bytes()
+            )
+            .unwrap_err(),
+            LmdbError::NotFound
+        );
+        source_txn.commit().unwrap();
+        destination_txn.commit().unwrap();
+    }
+
+    {
+        let destination_txn = destination_fixture.env.begin_ro_txn().unwrap();
+        let destination_db = destination_fixture.db(Some(MOCK_DB_NAME)).unwrap();
+        assert_eq!(
+            destination_txn
+                .get(*destination_db, &0usize.to_le_bytes())
+                .unwrap_err(),
+            LmdbError::NotFound
+        );
+        assert_eq!(
+            destination_txn
+                .get(*destination_db, &1usize.to_le_bytes())
+                .unwrap(),
+            bincode::serialize(&deploy_hashes[1]).unwrap()
+        );
+        assert_eq!(
+            destination_txn
+                .get(*destination_db, &2usize.to_le_bytes())
+                .unwrap(),
+            bincode::serialize(&deploy_hashes[2]).unwrap()
+        );
+        assert_eq!(
+            destination_txn
+                .get(*destination_db, &DATA_COUNT.to_le_bytes())
+                .unwrap_err(),
+            LmdbError::NotFound
+        );
+        destination_txn.commit().unwrap();
+    }
+}
+
+#[test]
+fn transfer_blocks() {
+    const BLOCK_COUNT: usize = 3;
+    const DEPLOY_COUNT: usize = 4;
+
+    let source_fixture = LmdbTestFixture::new(
+        vec![
+            BlockHeaderDatabase::db_name(),
+            BlockBodyDatabase::db_name(),
+            DeployMetadataDatabase::db_name(),
+            DeployDatabase::db_name(),
+            TransferDatabase::db_name(),
+        ],
+        Some(STORAGE_FILE_NAME),
+    );
+
+    let deploy_hashes: Vec<DeployHash> = (0..DEPLOY_COUNT as u8).map(mock_deploy_hash).collect();
+    let block_headers: Vec<(BlockHash, MockBlockHeader)> =
+        (0..BLOCK_COUNT as u8).map(mock_block_header).collect();
+    let mut block_bodies = vec![];
+    let mut block_body_deploy_map: Vec<Vec<usize>> = vec![];
+    block_bodies.push(BlockBody::new(vec![
+        deploy_hashes[0],
+        deploy_hashes[1],
+        deploy_hashes[3],
+    ]));
+    block_body_deploy_map.push(vec![0, 1, 3]);
+    block_bodies.push(BlockBody::new(vec![deploy_hashes[1], deploy_hashes[2]]));
+    block_body_deploy_map.push(vec![1, 2]);
+    block_bodies.push(BlockBody::new(vec![deploy_hashes[2], deploy_hashes[3]]));
+    block_body_deploy_map.push(vec![2, 3]);
+
+    let deploy_metadatas = vec![
+        mock_deploy_metadata(slice::from_ref(&block_headers[0].0)),
+        mock_deploy_metadata(&[block_headers[0].0, block_headers[1].0]),
+        mock_deploy_metadata(&[block_headers[1].0, block_headers[2].0]),
+        mock_deploy_metadata(&[block_headers[0].0, block_headers[2].0]),
+    ];
+
+    let env = &source_fixture.env;
+    // Insert the 3 blocks into the database.
+    {
+        let mut txn = env.begin_rw_txn().unwrap();
+        for i in 0..BLOCK_COUNT {
+            // Store the header.
+            txn.put(
+                *source_fixture
+                    .db(Some(BlockHeaderDatabase::db_name()))
+                    .unwrap(),
+                &block_headers[i].0,
+                &bincode::serialize(&block_headers[i].1).unwrap(),
+                WriteFlags::empty(),
+            )
+            .unwrap();
+            // Store the body.
+            txn.put(
+                *source_fixture
+                    .db(Some(BlockBodyDatabase::db_name()))
+                    .unwrap(),
+                &block_headers[i].1.body_hash,
+                &bincode::serialize(&block_bodies[i]).unwrap(),
+                WriteFlags::empty(),
+            )
+            .unwrap();
+        }
+
+        // Insert the 4 deploys into the deploys and deploy_metadata databases.
+        for i in 0..DEPLOY_COUNT {
+            txn.put(
+                *source_fixture
+                    .db(Some(DeployMetadataDatabase::db_name()))
+                    .unwrap(),
+                &deploy_hashes[i],
+                &bincode::serialize(&deploy_metadatas[i]).unwrap(),
+                WriteFlags::empty(),
+            )
+            .unwrap();
+            // Add mock deploy data in the database.
+            txn.put(
+                *source_fixture.db(Some(DeployDatabase::db_name())).unwrap(),
+                &deploy_hashes[i],
+                &bincode::serialize(&deploy_hashes[i]).unwrap(),
+                WriteFlags::empty(),
+            )
+            .unwrap();
+        }
+        txn.commit().unwrap();
+    };
+
+    let destination_fixture = LmdbTestFixture::new(
+        vec![
+            BlockHeaderDatabase::db_name(),
+            BlockBodyDatabase::db_name(),
+            DeployMetadataDatabase::db_name(),
+            DeployDatabase::db_name(),
+            TransferDatabase::db_name(),
+        ],
+        Some(STORAGE_FILE_NAME),
+    );
+
+    let block_hash_0 = block_headers[0].0;
+    let expected_state_root_hash = block_headers[0].1.state_root_hash;
+    let actual_state_root_hash = storage::transfer_block_info(
+        source_fixture.tmp_dir.path(),
+        destination_fixture.tmp_dir.path(),
+        block_hash_0,
+    )
+    .unwrap();
+    assert_eq!(expected_state_root_hash, actual_state_root_hash);
+
+    {
+        let txn = destination_fixture.env.begin_ro_txn().unwrap();
+        let actual_block_header: MockBlockHeader = txn
+            .get(
+                *destination_fixture
+                    .db(Some(BlockHeaderDatabase::db_name()))
+                    .unwrap(),
+                &block_hash_0,
+            )
+            .map(bincode::deserialize)
+            .unwrap()
+            .unwrap();
+        assert_eq!(actual_block_header, block_headers[0].1);
+
+        let actual_block_body: BlockBody = txn
+            .get(
+                *destination_fixture
+                    .db(Some(BlockBodyDatabase::db_name()))
+                    .unwrap(),
+                &actual_block_header.body_hash,
+            )
+            .map(bincode::deserialize)
+            .unwrap()
+            .unwrap();
+        assert_eq!(actual_block_body, block_bodies[0]);
+
+        for deploy_hash in actual_block_body.deploy_hashes() {
+            let actual_mock_deploy: DeployHash = txn
+                .get(
+                    *destination_fixture
+                        .db(Some(DeployDatabase::db_name()))
+                        .unwrap(),
+                    deploy_hash,
+                )
+                .map(bincode::deserialize)
+                .unwrap()
+                .unwrap();
+            assert_eq!(*deploy_hash, actual_mock_deploy);
+
+            let mut actual_deploy_metadata: DeployMetadata = txn
+                .get(
+                    *destination_fixture
+                        .db(Some(DeployMetadataDatabase::db_name()))
+                        .unwrap(),
+                    deploy_hash,
+                )
+                .map(bincode::deserialize)
+                .unwrap()
+                .unwrap();
+            assert!(actual_deploy_metadata
+                .execution_results
+                .remove(&block_hash_0)
+                .is_some());
+            assert!(actual_deploy_metadata.execution_results.is_empty());
+        }
+
+        assert_eq!(
+            txn.get(
+                *destination_fixture
+                    .db(Some(BlockHeaderDatabase::db_name()))
+                    .unwrap(),
+                &block_headers[1].0,
+            )
+            .unwrap_err(),
+            LmdbError::NotFound
+        );
+        assert_eq!(
+            txn.get(
+                *destination_fixture
+                    .db(Some(BlockHeaderDatabase::db_name()))
+                    .unwrap(),
+                &block_headers[2].0,
+            )
+            .unwrap_err(),
+            LmdbError::NotFound
+        );
+        txn.commit().unwrap();
+    }
+
+    let block_hash_1 = block_headers[1].0;
+
+    // Put some mock data in the transfer DB under block hash 1.
+    {
+        let mut txn = source_fixture.env.begin_rw_txn().unwrap();
+        txn.put(
+            *source_fixture
+                .db(Some(TransferDatabase::db_name()))
+                .unwrap(),
+            &block_hash_1,
+            &bincode::serialize(&block_hash_1).unwrap(),
+            WriteFlags::empty(),
+        )
+        .unwrap();
+        txn.commit().unwrap();
+    }
+
+    let expected_state_root_hash = block_headers[1].1.state_root_hash;
+    let actual_state_root_hash = storage::transfer_block_info(
+        source_fixture.tmp_dir.path(),
+        destination_fixture.tmp_dir.path(),
+        block_hash_1,
+    )
+    .unwrap();
+    assert_eq!(expected_state_root_hash, actual_state_root_hash);
+
+    {
+        let txn = destination_fixture.env.begin_ro_txn().unwrap();
+        let actual_block_header: MockBlockHeader = txn
+            .get(
+                *destination_fixture
+                    .db(Some(BlockHeaderDatabase::db_name()))
+                    .unwrap(),
+                &block_hash_1,
+            )
+            .map(bincode::deserialize)
+            .unwrap()
+            .unwrap();
+        assert_eq!(actual_block_header, block_headers[1].1);
+
+        let actual_block_body: BlockBody = txn
+            .get(
+                *destination_fixture
+                    .db(Some(BlockBodyDatabase::db_name()))
+                    .unwrap(),
+                &actual_block_header.body_hash,
+            )
+            .map(bincode::deserialize)
+            .unwrap()
+            .unwrap();
+        assert_eq!(actual_block_body, block_bodies[1]);
+
+        let actual_mock_transfer: BlockHash = txn
+            .get(
+                *destination_fixture
+                    .db(Some(TransferDatabase::db_name()))
+                    .unwrap(),
+                &block_hash_1,
+            )
+            .map(bincode::deserialize)
+            .unwrap()
+            .unwrap();
+        assert_eq!(block_hash_1, actual_mock_transfer);
+
+        for deploy_hash in actual_block_body.deploy_hashes() {
+            let actual_mock_deploy: DeployHash = txn
+                .get(
+                    *destination_fixture
+                        .db(Some(DeployDatabase::db_name()))
+                        .unwrap(),
+                    deploy_hash,
+                )
+                .map(bincode::deserialize)
+                .unwrap()
+                .unwrap();
+            assert_eq!(*deploy_hash, actual_mock_deploy);
+
+            let mut actual_deploy_metadata: DeployMetadata = txn
+                .get(
+                    *destination_fixture
+                        .db(Some(DeployMetadataDatabase::db_name()))
+                        .unwrap(),
+                    deploy_hash,
+                )
+                .map(bincode::deserialize)
+                .unwrap()
+                .unwrap();
+            assert!(actual_deploy_metadata
+                .execution_results
+                .remove(&block_hash_1)
+                .is_some());
+            assert!(actual_deploy_metadata.execution_results.is_empty());
+        }
+
+        assert_eq!(
+            txn.get(
+                *destination_fixture
+                    .db(Some(BlockHeaderDatabase::db_name()))
+                    .unwrap(),
+                &block_headers[2].0,
+            )
+            .unwrap_err(),
+            LmdbError::NotFound
+        );
+        txn.commit().unwrap();
+    }
+}
+
+#[test]
+fn transfer_global_state_information() {
+    let source_tmp_dir = tempfile::tempdir().unwrap();
+    let destination_tmp_dir = tempfile::tempdir().unwrap();
+    let max_db_size = DEFAULT_MAX_DB_SIZE
+        .parse()
+        .expect("should be able to parse max db size");
+    let source_env = LmdbEnvironment::new(source_tmp_dir.path(), max_db_size, 512, true).unwrap();
+    let source_store = LmdbTrieStore::new(&source_env, None, DatabaseFlags::empty()).unwrap();
+    // Construct mock data.
+    let data = create_data();
+
+    {
+        // Put the generated data into the source trie.
+        let mut txn = source_env.create_read_write_txn().unwrap();
+        let items = data.iter().map(Into::into);
+        source_store.put_many(&mut txn, items).unwrap();
+        txn.commit().unwrap();
+    }
+
+    let (_source_state, _env) =
+        load_execution_engine(source_tmp_dir.path(), max_db_size, Digest::default(), true).unwrap();
+
+    let (_destination_state, dst_env) =
+        create_execution_engine(destination_tmp_dir.path(), max_db_size, true).unwrap();
+
+    // Copy from `node2`, the root of the created trie. All data under node 2,
+    // which has leaf 2 and 3 under it, should be copied.
+    global_state::transfer_global_state(
+        source_tmp_dir.path(),
+        destination_tmp_dir.path(),
+        data[4].0,
+    )
+    .unwrap();
+
+    let destination_store = LmdbTrieStore::new(&dst_env, None, DatabaseFlags::empty()).unwrap();
+    {
+        let txn = dst_env.create_read_write_txn().unwrap();
+        let keys = vec![data[1].0, data[2].0, data[4].0];
+        let entries: Vec<Option<Trie<Bytes, Bytes>>> =
+            destination_store.get_many(&txn, keys.iter()).unwrap();
+        for entry in entries {
+            match entry {
+                Some(trie) => {
+                    let trie_in_data = data.iter().find(|test_data| test_data.1 == trie);
+                    // Check we are not missing anything since all data under
+                    // node 2 should be copied.
+                    assert!(trie_in_data.is_some());
+                    // Hashes should be equal.
+                    assert_eq!(
+                        trie_in_data.unwrap().0,
+                        Digest::hash(&trie.to_bytes().unwrap())
+                    );
+                }
+                None => panic!(),
+            }
+        }
+        txn.commit().unwrap();
+    }
+
+    source_tmp_dir.close().unwrap();
+    destination_tmp_dir.close().unwrap();
+}

--- a/src/subcommands/latest_block_summary/read_db.rs
+++ b/src/subcommands/latest_block_summary/read_db.rs
@@ -95,7 +95,7 @@ pub fn latest_block_summary<P1: AsRef<Path>, P2: AsRef<Path>>(
     overwrite: bool,
 ) -> Result<(), Error> {
     let storage_path = db_path.as_ref().join(STORAGE_FILE_NAME);
-    let env = db::db_env(&storage_path)?;
+    let env = db::db_env(storage_path)?;
     let mut log_progress = false;
     // Validate the output file early so that, in case this fails
     // we don't unnecessarily read the whole database.

--- a/src/subcommands/latest_block_summary/tests.rs
+++ b/src/subcommands/latest_block_summary/tests.rs
@@ -35,7 +35,7 @@ fn parse_network_name_input() {
     );
     let relative_path_to_first_node = second_node.as_ref().join("..");
     assert_eq!(
-        block_info::parse_network_name(&relative_path_to_first_node).unwrap(),
+        block_info::parse_network_name(relative_path_to_first_node).unwrap(),
         first_node.path().file_name().unwrap().to_str().unwrap()
     );
 

--- a/src/subcommands/trie_compact.rs
+++ b/src/subcommands/trie_compact.rs
@@ -1,7 +1,7 @@
 mod compact;
 mod helpers;
 #[cfg(test)]
-mod tests;
+pub(crate) mod tests;
 // All code in the `utils` mod was copied from `casper-node` because it isn't available in the
 // public interface.
 mod utils;
@@ -17,13 +17,15 @@ use casper_hashing::Digest;
 use casper_node::storage::Error as StorageError;
 
 use compact::DestinationOptions;
+pub use helpers::copy_state_root;
+pub use utils::{create_execution_engine, load_execution_engine};
 
 pub const COMMAND_NAME: &str = "compact-trie";
 const APPEND: &str = "append";
 const DESTINATION_TRIE_STORE_PATH: &str = "dest-trie";
 const OVERWRITE: &str = "overwrite";
 const MAX_DB_SIZE: &str = "max-db-size";
-const DEFAULT_MAX_DB_SIZE: &str = "483183820800"; // 450 gb
+pub const DEFAULT_MAX_DB_SIZE: &str = "483183820800"; // 450 gb
 const SOURCE_TRIE_STORE_PATH: &str = "src-trie";
 const STORAGE_PATH: &str = "storage-path";
 
@@ -141,7 +143,7 @@ pub fn command(display_order: usize) -> Command<'static> {
                 .short('m')
                 .long(MAX_DB_SIZE)
                 .takes_value(true)
-                .default_value(DEFAULT_MAX_DB_SIZE)
+                .default_value(MAX_DB_SIZE)
                 .value_name("MAX_DB_SIZE")
                 .help("Maximum size the DB files are allowed to be, in bytes."),
         )

--- a/src/subcommands/trie_compact.rs
+++ b/src/subcommands/trie_compact.rs
@@ -143,7 +143,7 @@ pub fn command(display_order: usize) -> Command<'static> {
                 .short('m')
                 .long(MAX_DB_SIZE)
                 .takes_value(true)
-                .default_value(MAX_DB_SIZE)
+                .default_value(DEFAULT_MAX_DB_SIZE)
                 .value_name("MAX_DB_SIZE")
                 .help("Maximum size the DB files are allowed to be, in bytes."),
         )

--- a/src/subcommands/trie_compact/compact.rs
+++ b/src/subcommands/trie_compact/compact.rs
@@ -91,8 +91,7 @@ fn validate_trie_paths<P1: AsRef<Path>, P2: AsRef<Path>>(
                         .open(destination_trie_path.as_ref().join(TRIE_STORE_FILE_NAME))
                         .map_err(|io_err| {
                             Error::InvalidDest(format!(
-                                "Couldn't overwrite destination file: {}",
-                                io_err
+                                "Couldn't overwrite destination file: {io_err}"
                             ))
                         })?;
                 } else {

--- a/src/subcommands/trie_compact/compact.rs
+++ b/src/subcommands/trie_compact/compact.rs
@@ -8,12 +8,12 @@ use log::info;
 
 use casper_hashing::Digest;
 
+use crate::common::db::TRIE_STORE_FILE_NAME;
+
 use super::{
     utils::{create_execution_engine, create_storage, load_execution_engine},
     Error,
 };
-
-pub(crate) const TRIE_STORE_FILE_NAME: &str = "data.lmdb";
 
 /// Defines behavior for opening destination trie store.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/src/subcommands/trie_compact/helpers.rs
+++ b/src/subcommands/trie_compact/helpers.rs
@@ -18,10 +18,10 @@ use casper_types::{
     Key, StoredValue,
 };
 
-fn memoized_find_missing_descendants<'env>(
+fn memoized_find_missing_descendants(
     value_bytes: Bytes,
     trie_store: &LmdbTrieStore,
-    txn: &RwTransaction<'env>,
+    txn: &RwTransaction<'_>,
     missing_trie_keys: &mut Vec<Digest>,
     time_in_missing_trie_keys: &mut Duration,
 ) -> Result<(), anyhow::Error> {
@@ -51,11 +51,11 @@ fn memoized_find_missing_descendants<'env>(
     Ok(())
 }
 
-fn find_missing_trie_keys<'env>(
+fn find_missing_trie_keys(
     ptr: Pointer,
     missing_trie_keys: &mut Vec<Digest>,
     handle: &LmdbTrieStore,
-    txn: &RwTransaction<'env>,
+    txn: &RwTransaction<'_>,
 ) -> Result<(), anyhow::Error> {
     let ptr = match ptr {
         Pointer::LeafPointer(pointer) | Pointer::NodePointer(pointer) => pointer,

--- a/src/subcommands/trie_compact/tests.rs
+++ b/src/subcommands/trie_compact/tests.rs
@@ -48,9 +48,9 @@ pub(crate) fn create_data() -> Vec<TestData<Bytes, Bytes>> {
         value: Bytes::from(b"val_3".to_vec()),
     };
 
-    let leaf_1_hash = Digest::hash(&leaf_1.to_bytes().unwrap());
-    let leaf_2_hash = Digest::hash(&leaf_2.to_bytes().unwrap());
-    let leaf_3_hash = Digest::hash(&leaf_3.to_bytes().unwrap());
+    let leaf_1_hash = Digest::hash(leaf_1.to_bytes().unwrap());
+    let leaf_2_hash = Digest::hash(leaf_2.to_bytes().unwrap());
+    let leaf_3_hash = Digest::hash(leaf_3.to_bytes().unwrap());
 
     let node_2: Trie<Bytes, Bytes> = {
         let mut pointer_block = PointerBlock::new();
@@ -60,7 +60,7 @@ pub(crate) fn create_data() -> Vec<TestData<Bytes, Bytes>> {
         Trie::Node { pointer_block }
     };
 
-    let node_2_hash = Digest::hash(&node_2.to_bytes().unwrap());
+    let node_2_hash = Digest::hash(node_2.to_bytes().unwrap());
 
     let ext_node: Trie<Bytes, Bytes> = {
         let affix = vec![1u8, 0];
@@ -71,7 +71,7 @@ pub(crate) fn create_data() -> Vec<TestData<Bytes, Bytes>> {
         }
     };
 
-    let ext_node_hash = Digest::hash(&ext_node.to_bytes().unwrap());
+    let ext_node_hash = Digest::hash(ext_node.to_bytes().unwrap());
 
     let node_1: Trie<Bytes, Bytes> = {
         let mut pointer_block = PointerBlock::new();
@@ -81,7 +81,7 @@ pub(crate) fn create_data() -> Vec<TestData<Bytes, Bytes>> {
         Trie::Node { pointer_block }
     };
 
-    let node_1_hash = Digest::hash(&node_1.to_bytes().unwrap());
+    let node_1_hash = Digest::hash(node_1.to_bytes().unwrap());
 
     vec![
         TestData(leaf_1_hash, leaf_1),
@@ -259,7 +259,7 @@ fn missing_source_trie() {
         *DEFAULT_MAX_DB_SIZE,
     ) {
         Err(Error::InvalidPath(..)) => {}
-        Err(err) => panic!("Unexpected error: {}", err),
+        Err(err) => panic!("Unexpected error: {err}"),
         Ok(_) => panic!("Unexpected successful trie compact"),
     }
 }
@@ -276,7 +276,7 @@ fn missing_storage() {
         *DEFAULT_MAX_DB_SIZE,
     ) {
         Err(Error::OpenStorage(_)) => {}
-        Err(err) => panic!("Unexpected error: {}", err),
+        Err(err) => panic!("Unexpected error: {err}"),
         Ok(_) => panic!("Unexpected successful trie compact"),
     }
 }
@@ -294,7 +294,7 @@ fn valid_empty_dst_with_destination_options() {
         *DEFAULT_MAX_DB_SIZE,
     ) {
         Ok(_) => {}
-        Err(err) => panic!("Unexpected error: {}", err),
+        Err(err) => panic!("Unexpected error: {err}"),
     }
     fs::remove_file(dst_dir.path().join(TRIE_STORE_FILE_NAME)).unwrap();
 
@@ -306,7 +306,7 @@ fn valid_empty_dst_with_destination_options() {
         *DEFAULT_MAX_DB_SIZE,
     ) {
         Err(Error::InvalidDest(_)) => {}
-        Err(err) => panic!("Unexpected error: {}", err),
+        Err(err) => panic!("Unexpected error: {err}"),
         Ok(_) => panic!("Unexpected successful trie compact"),
     }
 
@@ -318,7 +318,7 @@ fn valid_empty_dst_with_destination_options() {
         *DEFAULT_MAX_DB_SIZE,
     ) {
         Err(Error::InvalidDest(_)) => {}
-        Err(err) => panic!("Unexpected error: {}", err),
+        Err(err) => panic!("Unexpected error: {err}"),
         Ok(_) => panic!("Unexpected successful trie compact"),
     }
 }
@@ -341,7 +341,7 @@ fn valid_existing_dst_with_destination_options() {
         *DEFAULT_MAX_DB_SIZE,
     ) {
         Err(Error::InvalidDest(_)) => {}
-        Err(err) => panic!("Unexpected error: {}", err),
+        Err(err) => panic!("Unexpected error: {err}"),
         Ok(_) => panic!("Unexpected successful trie compact"),
     }
 
@@ -353,7 +353,7 @@ fn valid_existing_dst_with_destination_options() {
         *DEFAULT_MAX_DB_SIZE,
     ) {
         Ok(_) => {}
-        Err(err) => panic!("Unexpected error: {}", err),
+        Err(err) => panic!("Unexpected error: {err}"),
     }
 
     assert!(dst_dir.path().join(TRIE_STORE_FILE_NAME).exists());
@@ -365,7 +365,7 @@ fn valid_existing_dst_with_destination_options() {
         *DEFAULT_MAX_DB_SIZE,
     ) {
         Ok(_) => {}
-        Err(err) => panic!("Unexpected error: {}", err),
+        Err(err) => panic!("Unexpected error: {err}"),
     }
 
     fs::remove_file(dst_dir.path().join(TRIE_STORE_FILE_NAME))
@@ -386,7 +386,7 @@ fn missing_dst_with_destination_options() {
         *DEFAULT_MAX_DB_SIZE,
     ) {
         Ok(_) => {}
-        Err(err) => panic!("Unexpected error: {}", err),
+        Err(err) => panic!("Unexpected error: {err}"),
     }
     fs::remove_dir_all(dst_dir.as_path()).unwrap();
 
@@ -398,7 +398,7 @@ fn missing_dst_with_destination_options() {
         *DEFAULT_MAX_DB_SIZE,
     ) {
         Err(Error::InvalidDest(_)) => {}
-        Err(err) => panic!("Unexpected error: {}", err),
+        Err(err) => panic!("Unexpected error: {err}"),
         Ok(_) => panic!("Unexpected successful trie compact"),
     }
 
@@ -410,7 +410,7 @@ fn missing_dst_with_destination_options() {
         *DEFAULT_MAX_DB_SIZE,
     ) {
         Err(Error::InvalidDest(_)) => {}
-        Err(err) => panic!("Unexpected error: {}", err),
+        Err(err) => panic!("Unexpected error: {err}"),
         Ok(_) => panic!("Unexpected successful trie compact"),
     }
 }

--- a/src/subcommands/trie_compact/tests.rs
+++ b/src/subcommands/trie_compact/tests.rs
@@ -16,14 +16,16 @@ use casper_types::bytesrepr::{Bytes, ToBytes};
 
 static DEFAULT_MAX_DB_SIZE: Lazy<usize> = Lazy::new(|| super::DEFAULT_MAX_DB_SIZE.parse().unwrap());
 
+use crate::common::db::TRIE_STORE_FILE_NAME;
+
 use super::{
-    compact::{self, DestinationOptions, TRIE_STORE_FILE_NAME},
+    compact::{self, DestinationOptions},
     utils::{create_execution_engine, create_storage, load_execution_engine},
     Error,
 };
 
 #[derive(Clone, Debug, PartialEq)]
-struct TestData<K, V>(Digest, Trie<K, V>);
+pub(crate) struct TestData<K, V>(pub(crate) Digest, pub(crate) Trie<K, V>);
 
 impl<'a, K, V> From<&'a TestData<K, V>> for (&'a Digest, &'a Trie<K, V>) {
     fn from(test_data: &'a TestData<K, V>) -> Self {
@@ -32,7 +34,7 @@ impl<'a, K, V> From<&'a TestData<K, V>> for (&'a Digest, &'a Trie<K, V>) {
 }
 
 // Copied from `execution_engine::storage::trie_store::tests::create_data`
-fn create_data() -> Vec<TestData<Bytes, Bytes>> {
+pub(crate) fn create_data() -> Vec<TestData<Bytes, Bytes>> {
     let leaf_1 = Trie::Leaf {
         key: Bytes::from(vec![0u8, 0, 0]),
         value: Bytes::from(b"val_1".to_vec()),

--- a/src/subcommands/trie_compact/utils.rs
+++ b/src/subcommands/trie_compact/utils.rs
@@ -18,7 +18,7 @@ use casper_node::{storage::Storage, StorageConfig, WithDir};
 use casper_types::ProtocolVersion;
 use lmdb::DatabaseFlags;
 
-use super::compact::TRIE_STORE_FILE_NAME;
+use crate::common::db::TRIE_STORE_FILE_NAME;
 
 /// LMDB max readers
 ///

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -7,8 +7,8 @@ use serde::{Deserialize, Serialize};
 use tempfile::{NamedTempFile, TempDir};
 
 use casper_hashing::Digest;
-use casper_node::types::{BlockHash, Timestamp};
-use casper_types::{EraId, ProtocolVersion};
+use casper_node::types::{BlockHash, DeployHash, DeployMetadata, Timestamp};
+use casper_types::{EraId, ExecutionEffect, ExecutionResult, ProtocolVersion};
 
 pub struct LmdbTestFixture {
     pub env: Environment,
@@ -115,5 +115,35 @@ impl Default for MockBlockHeader {
             height: Default::default(),
             protocol_version: Default::default(),
         }
+    }
+}
+
+pub(crate) fn mock_deploy_hash(idx: u8) -> DeployHash {
+    DeployHash::new([idx; 32].into())
+}
+
+pub(crate) fn mock_block_header(idx: u8) -> (BlockHash, MockBlockHeader) {
+    let mut block_header = MockBlockHeader::default();
+    let block_hash_digest: Digest = [idx; Digest::LENGTH].into();
+    let block_hash: BlockHash = block_hash_digest.into();
+    block_header.body_hash = [idx; Digest::LENGTH].into();
+    (block_hash, block_header)
+}
+
+pub(crate) fn mock_deploy_metadata(block_hashes: &[BlockHash]) -> DeployMetadata {
+    let mut deploy_metadata = DeployMetadata::default();
+    for block_hash in block_hashes {
+        deploy_metadata
+            .execution_results
+            .insert(*block_hash, success_execution_result());
+    }
+    deploy_metadata
+}
+
+pub(crate) fn success_execution_result() -> ExecutionResult {
+    ExecutionResult::Success {
+        effect: ExecutionEffect::default(),
+        transfers: vec![],
+        cost: 100.into(),
     }
 }


### PR DESCRIPTION
Fixes #27 and #28 

This PR introduces the `extract-slice` subcommand which, given a block hash and a source database, will copy all the information related to the block (block header, block body, deploys, execution results, global state under its state root hash) to a new database.

Additionally, this PR also updates the dependencies in `Cargo.lock` as they were old and became vulnerable.