### PR TITLE
Add `purge-signatures` subcommand

### DIFF
--- a/.github/workflows/ci-casper-db-utils.yml
+++ b/.github/workflows/ci-casper-db-utils.yml
@@ -43,7 +43,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: audit
-          args: --deny warnings --ignore RUSTSEC-2022-0001 --ignore RUSTSEC-2020-0071 --ignore RUSTSEC-2021-0139 --ignore RUSTSEC-2022-0061 --ignore RUSTSEC-2021-0145 --ignore RUSTSEC-2021-0146 --ignore RUSTSEC-2022-0041
+          args: --deny warnings --ignore RUSTSEC-2022-0001 --ignore RUSTSEC-2020-0071 --ignore RUSTSEC-2021-0139 --ignore RUSTSEC-2022-0061 --ignore RUSTSEC-2021-0145 --ignore RUSTSEC-2021-0146 --ignore RUSTSEC-2022-0041 --ignore RUSTSEC-2020-0168 --ignore RUSTSEC-2022-0092
 
       - name: Clippy
         uses: actions-rs/cargo@v1

--- a/.github/workflows/ci-casper-db-utils.yml
+++ b/.github/workflows/ci-casper-db-utils.yml
@@ -43,7 +43,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: audit
-          args: --deny warnings --ignore RUSTSEC-2022-0001 --ignore RUSTSEC-2020-0071 --ignore RUSTSEC-2021-0139 --ignore RUSTSEC-2022-0061 --ignore RUSTSEC-2021-0145 --ignore RUSTSEC-2021-0146 --ignore RUSTSEC-2022-0041 --ignore RUSTSEC-2020-0168 --ignore RUSTSEC-2022-0092
+          args: --deny warnings --ignore RUSTSEC-2022-0001 --ignore RUSTSEC-2020-0071 --ignore RUSTSEC-2021-0139 --ignore RUSTSEC-2022-0061 --ignore RUSTSEC-2021-0145 --ignore RUSTSEC-2021-0146 --ignore RUSTSEC-2022-0041 --ignore RUSTSEC-2020-0168 --ignore RUSTSEC-2022-0092 --ignore RUSTSEC-2023-0034
 
       - name: Clippy
         uses: actions-rs/cargo@v1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -71,9 +71,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.69"
+version = "1.0.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "224afbd727c3d6e4b90103ece64b8d1b67fbb1973b1046c2281eed3f3803f800"
+checksum = "7de8ce5e0f9f8d88245311066a578d72b7af3e7088f32783804676302df237e4"
 
 [[package]]
 name = "async-compression"
@@ -91,13 +91,13 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.64"
+version = "0.1.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cd7fce9ba8c3c042128ce72d8b2ddbf3a05747efb67ea0313c635e10bda47a2"
+checksum = "b9ccdd8f2a161be9bd5c023df56f1b2a0bd1d83872ae53b71a84a12c9bf6e842"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.13",
 ]
 
 [[package]]
@@ -222,9 +222,9 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
-version = "0.10.3"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cce20737498f97b993470a6e536b8523f0af7892a4f928cceb1ac5e52ebe7e"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
 ]
@@ -248,16 +248,6 @@ checksum = "4b6561fd3f895a11e8f72af2cb7d22e08366bebc2b6b57f7744c4bda27034744"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
-]
-
-[[package]]
-name = "buf_redux"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b953a6887648bb07a535631f2bc00fbdb2a2216f135552cb3f534ed136b9c07f"
-dependencies = [
- "memchr",
- "safemem",
 ]
 
 [[package]]
@@ -290,7 +280,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bincode",
- "casper-execution-engine",
+ "casper-execution-engine 2.0.1",
  "casper-hashing",
  "casper-node",
  "casper-types",
@@ -357,6 +347,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "casper-execution-engine"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50dec17ae0daadfbcc2bb0a085189ede068bf288b078506490420117f4535625"
+dependencies = [
+ "anyhow",
+ "base16",
+ "bincode",
+ "casper-hashing",
+ "casper-types",
+ "chrono",
+ "datasize",
+ "hex-buffer-serde 0.2.2",
+ "hex_fmt",
+ "hostname",
+ "itertools",
+ "libc",
+ "linked-hash-map",
+ "lmdb",
+ "log",
+ "num",
+ "num-derive",
+ "num-rational 0.4.1",
+ "num-traits",
+ "num_cpus",
+ "once_cell",
+ "parity-wasm",
+ "proptest",
+ "pwasm-utils",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
+ "schemars",
+ "serde",
+ "serde_bytes",
+ "serde_json",
+ "thiserror",
+ "tracing",
+ "uint",
+ "uuid",
+ "wasmi",
+]
+
+[[package]]
 name = "casper-hashing"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -376,9 +409,9 @@ dependencies = [
 
 [[package]]
 name = "casper-node"
-version = "1.4.8"
+version = "1.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd9ced1522ff0b6958a358c5f81624fb81e01dddba5a82a1cc6d1eacdec96dd6"
+checksum = "055ec2b61e829acf813fdda0b5ebd82c40b3f46800fc9098f6fa78a103845108"
 dependencies = [
  "ansi_term",
  "anyhow",
@@ -388,7 +421,7 @@ dependencies = [
  "base64 0.13.1",
  "bincode",
  "bytes",
- "casper-execution-engine",
+ "casper-execution-engine 3.0.0",
  "casper-hashing",
  "casper-node-macros",
  "casper-types",
@@ -476,7 +509,7 @@ dependencies = [
  "indexmap",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -532,9 +565,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.23"
+version = "0.4.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16b0a3d9ed01224b22057780a37bb8c5dbfe1be8ba48678e7bf57ec4b385411f"
+checksum = "4e3c5919066adf22df73762e50cffcde3a758f2a848b113b586d1f86728b673b"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -619,15 +652,15 @@ dependencies = [
 
 [[package]]
 name = "core-foundation-sys"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
+checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d997bd5e24a5928dd43e46dc529867e207907fe0b239c3477d924f7f2ca320"
+checksum = "280a9f2d8b3a38871a3c8a46fb80db65e5e5ed97da80c4d08bf27fb63e35e181"
 dependencies = [
  "libc",
 ]
@@ -756,7 +789,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d2301688392eb071b0bf1a37be05c469d3cc4dbbd95df672fe28ab021e6a096"
 dependencies = [
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -774,9 +807,9 @@ dependencies = [
 
 [[package]]
 name = "cxx"
-version = "1.0.91"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86d3488e7665a7a483b57e25bdd90d0aeb2bc7608c8d0346acf2ad3f1caf1d62"
+checksum = "f61f1b6389c3fe1c316bf8a4dccc90a38208354b330925bce1f74a6c4756eb93"
 dependencies = [
  "cc",
  "cxxbridge-flags",
@@ -786,9 +819,9 @@ dependencies = [
 
 [[package]]
 name = "cxx-build"
-version = "1.0.91"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48fcaf066a053a41a81dfb14d57d99738b767febb8b735c3016e469fac5da690"
+checksum = "12cee708e8962df2aeb38f594aae5d827c022b6460ac71a7a3e2c3c2aae5a07b"
 dependencies = [
  "cc",
  "codespan-reporting",
@@ -796,31 +829,31 @@ dependencies = [
  "proc-macro2",
  "quote",
  "scratch",
- "syn",
+ "syn 2.0.13",
 ]
 
 [[package]]
 name = "cxxbridge-flags"
-version = "1.0.91"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2ef98b8b717a829ca5603af80e1f9e2e48013ab227b68ef37872ef84ee479bf"
+checksum = "7944172ae7e4068c533afbb984114a56c46e9ccddda550499caa222902c7f7bb"
 
 [[package]]
 name = "cxxbridge-macro"
-version = "1.0.91"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "086c685979a698443656e5cf7856c95c642295a38599f12fb1ff76fb28d19892"
+checksum = "2345488264226bf682893e25de0769f3360aac9957980ec49361b083ddaa5bc5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.13",
 ]
 
 [[package]]
 name = "datasize"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3319c13ed12c1ce89494db62541bc66759c8870c3562bdf7b25b930420a00432"
+checksum = "c88ad90721dc8e2ebe1430ac2f59c5bdcd74478baa68da26f30f33b0fe997f11"
 dependencies = [
  "datasize_derive",
  "fake_instant",
@@ -831,13 +864,13 @@ dependencies = [
 
 [[package]]
 name = "datasize_derive"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4abd50b37ab87677c31190aad6b4186be9993a618ff753c4b007551de6841ee8"
+checksum = "8b0415ec81945214410892a00d4b5dd4566f6263205184248e018a3fe384a61e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -859,7 +892,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -886,7 +919,7 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
 dependencies = [
- "block-buffer 0.10.3",
+ "block-buffer 0.10.4",
  "crypto-common",
 ]
 
@@ -898,9 +931,9 @@ checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
 
 [[package]]
 name = "dyn-clone"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9b0705efd4599c15a38151f4721f7bc388306f61084d3bfd50bd07fbca5cb60"
+checksum = "68b0cf012f1230e43cd00ebb729c6bb58707ecfa8ad08b52ef3a4ccd2697fc30"
 
 [[package]]
 name = "ecdsa"
@@ -947,7 +980,7 @@ dependencies = [
  "enum-ordinalize",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1000,7 +1033,7 @@ checksum = "1e94aa31f7c0dc764f57896dc615ddd76fc13b0d5dca7eb6cc5e018a5a09ec06"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1014,16 +1047,37 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
 name = "erased-serde"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4ca605381c017ec7a5fef5e548f1cfaa419ed0f6df6367339300db74c92aa7d"
+checksum = "4f2b0c2380453a92ea8b6c8e5f64ecaafccddde8ceab55ff7a8ac1029f894569"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "errno"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50d6a0976c999d473fe89ad888d5a284e55366d9dc9038b1ba2aa15128c4afa0"
+dependencies = [
+ "errno-dragonfly",
+ "libc",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "errno-dragonfly"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
+dependencies = [
+ "cc",
+ "libc",
 ]
 
 [[package]]
@@ -1060,7 +1114,7 @@ checksum = "8a3de6e8d11b22ff9edc6d916f890800597d60f8b2da1caf2955c274638d6412"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.2.16",
  "windows-sys 0.45.0",
 ]
 
@@ -1128,9 +1182,9 @@ checksum = "fed34cd105917e91daa4da6b3728c47b068749d6a62c59811f06ed2ac71d9da7"
 
 [[package]]
 name = "futures"
-version = "0.3.26"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13e2792b0ff0340399d58445b88fd9770e3489eff258a4cbc1523418f12abf84"
+checksum = "23342abe12aba583913b2e62f22225ff9c950774065e4bfb61a19cd9770fec40"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1143,9 +1197,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.26"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e5317663a9089767a1ec00a487df42e0ca174b61b4483213ac24448e4664df5"
+checksum = "955518d47e09b25bbebc7a18df10b81f0c766eaf4c4f1cccef2fca5f2a4fb5f2"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1153,15 +1207,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.26"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec90ff4d0fe1f57d600049061dc6bb68ed03c7d2fbd697274c41805dcb3f8608"
+checksum = "4bca583b7e26f571124fe5b7561d49cb2868d79116cfa0eefce955557c6fee8c"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.26"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8de0a35a6ab97ec8869e32a2473f4b1324459e14c29275d14b10cb1fd19b50e"
+checksum = "ccecee823288125bd88b4d7f565c9e58e41858e47ab72e8ea2d64e93624386e0"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1170,38 +1224,38 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.26"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfb8371b6fb2aeb2d280374607aeabfc99d95c72edfe51692e42d3d7f0d08531"
+checksum = "4fff74096e71ed47f8e023204cfd0aa1289cd54ae5430a9523be060cdb849964"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.26"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95a73af87da33b5acf53acfebdc339fe592ecf5357ac7c0a7734ab9d8c876a70"
+checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.13",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.26"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f310820bb3e8cfd46c80db4d7fb8353e15dfff853a127158425f31e0be6c8364"
+checksum = "f43be4fe21a13b9781a69afa4985b0f6ee0e1afab2c6f454a8cf30e2b2237b6e"
 
 [[package]]
 name = "futures-task"
-version = "0.3.26"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcf79a1bf610b10f42aea489289c5a2c478a786509693b80cd39c44ccd936366"
+checksum = "76d3d132be6c0e6aa1534069c705a74a5997a356c0dc2f86a47765e5617c5b65"
 
 [[package]]
 name = "futures-util"
-version = "0.3.26"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c1d6de3acfef38d2be4b1f543f553131788603495be83da675e180c8d6b7bd1"
+checksum = "26b01e40b772d54cf6c6d721c1d1abd0647a0106a12ecaa1c186273392a69533"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1217,9 +1271,9 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "0.14.6"
+version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bff49e947297f3312447abdca79f45f4738097cc82b06e72054d2223f601f1b9"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
@@ -1255,9 +1309,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.15"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f9f29bc9dda355256b2916cf526ab02ce0aeaaaf2bad60d65ef3f12f11dd0f4"
+checksum = "5be7b54589b581f624f566bf5d8eb2bab1db736c51528720b6bd36b96b55924d"
 dependencies = [
  "bytes",
  "fnv",
@@ -1329,6 +1383,12 @@ checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "hermit-abi"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
 
 [[package]]
 name = "hex"
@@ -1428,9 +1488,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.24"
+version = "0.14.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e011372fa0b68db8350aa7a248930ecc7839bf46d8485577d69f117a75f164c"
+checksum = "cc5e554ff619822309ffd57d8734d77cd5ce6238bc956f037ea06c58238c9899"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1465,16 +1525,16 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.53"
+version = "0.1.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64c122667b287044802d6ce17ee2ddf13207ed924c712de9a66a5814d5b64765"
+checksum = "0722cd7114b7de04316e7ea5456a0bbb20e4adb46fd27a3697adb812cff0f37c"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
  "iana-time-zone-haiku",
  "js-sys",
  "wasm-bindgen",
- "winapi",
+ "windows",
 ]
 
 [[package]]
@@ -1499,9 +1559,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.9.2"
+version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
  "hashbrown",
@@ -1518,10 +1578,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "ipnet"
-version = "2.7.1"
+name = "io-lifetimes"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30e22bd8629359895450b59ea7a776c850561b96a3b1d31321c1949d9e6c9146"
+checksum = "9c66c74d2ae7e79a5a8f7ac924adbe38ee42a859c6539ad869eb51f0b52dc220"
+dependencies = [
+ "hermit-abi 0.3.1",
+ "libc",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "ipnet"
+version = "2.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12b6ee2129af8d4fb011108c73d99a1b83a85977f23b82460c0ae2e25bb4b57f"
 
 [[package]]
 name = "itertools"
@@ -1534,9 +1605,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fad582f4b9e86b6caa621cabeb0963332d92eea04729ab12892c2533951e6440"
+checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
 
 [[package]]
 name = "jemalloc-ctl"
@@ -1572,9 +1643,9 @@ dependencies = [
 
 [[package]]
 name = "jobserver"
-version = "0.1.25"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "068b1ee6743e4d11fb9c6a1e6064b3693a1b600e7f5f5988047d98b3dc9fb90b"
+checksum = "936cfd212a0155903bcbc060e316fb6cc7cbf2e1907329391ebadc1fe0ce77c2"
 dependencies = [
  "libc",
 ]
@@ -1614,9 +1685,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.139"
+version = "0.2.141"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
+checksum = "3304a64d199bb964be99741b7a14d26972741915b3649639149b2479bb46f4b5"
 
 [[package]]
 name = "libm"
@@ -1638,6 +1709,12 @@ name = "linked-hash-map"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d59d8c75012853d2e872fb56bc8a2e53718e2cafe1a4c823143141c6d90c322f"
 
 [[package]]
 name = "lmdb"
@@ -1735,9 +1812,9 @@ checksum = "71d96e3f3c0b6325d8ccd83c33b28acb183edcb6c67938ba104ec546854b0882"
 
 [[package]]
 name = "mime"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "mime_guess"
@@ -1771,21 +1848,17 @@ dependencies = [
 ]
 
 [[package]]
-name = "multipart"
-version = "0.18.0"
+name = "multiparty"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00dec633863867f29cb39df64a397cdf4a6354708ddd7759f70c7fb51c5f9182"
+checksum = "ed1ec6589a6d4a1e0b33b4c0a3f6ee96dfba88ebdb3da51403fd7cf0a24a4b04"
 dependencies = [
- "buf_redux",
+ "bytes",
+ "futures-core",
  "httparse",
- "log",
- "mime",
- "mime_guess",
- "quick-error 1.2.3",
- "rand 0.8.5",
- "safemem",
- "tempfile",
- "twoway",
+ "memchr",
+ "pin-project-lite",
+ "try-lock",
 ]
 
 [[package]]
@@ -1859,7 +1932,7 @@ checksum = "876a53fff98e03a936a674b29568b0e605f06b29372c2489ff4de23f1949743d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1960,9 +2033,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
-version = "0.10.45"
+version = "0.10.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b102428fd03bc5edf97f62620f7298614c45cedf287c271e7ed450bbaf83f2e1"
+checksum = "4d2f106ab837a24e03672c59b1239669a0596406ff657c3c0835b6b7f0f35a33"
 dependencies = [
  "bitflags",
  "cfg-if 1.0.0",
@@ -1975,13 +2048,13 @@ dependencies = [
 
 [[package]]
 name = "openssl-macros"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b501e44f11665960c7e7fcf062c7d96a14ade4aa98116c004b2e37b5be7d736c"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.13",
 ]
 
 [[package]]
@@ -1992,11 +2065,10 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.80"
+version = "0.9.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23bbbf7854cd45b83958ebe919f0e8e516793727652e27fda10a8384cfc790b7"
+checksum = "3a20eace9dc2d82904039cb76dcf50fb1a0bba071cfd1629720b5d6f1ddba0fa"
 dependencies = [
- "autocfg",
  "cc",
  "libc",
  "pkg-config",
@@ -2005,9 +2077,9 @@ dependencies = [
 
 [[package]]
 name = "os_str_bytes"
-version = "6.4.1"
+version = "6.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b7820b9daea5457c9f21c69448905d723fbd21136ccf521748f23fd49e723ee"
+checksum = "ceedf44fb00f2d1984b0bc98102627ce622e083e49a5bacdb3e514fa4238e267"
 
 [[package]]
 name = "parity-wasm"
@@ -2045,7 +2117,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "instant",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.2.16",
  "smallvec",
  "winapi",
 ]
@@ -2058,7 +2130,7 @@ checksum = "9069cbb9f99e3a5083476ccb29ceb1de18b9118cafa53e90c9551235de2b9521"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.2.16",
  "smallvec",
  "windows-sys 0.45.0",
 ]
@@ -2075,9 +2147,9 @@ dependencies = [
 
 [[package]]
 name = "paste"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d01a5bd0424d00070b0098dd17ebca6f961a959dead1dbcbbbc1d1cd8d3deeba"
+checksum = "9f746c4065a8fa3fe23974dd82f15431cc8d40779821001404d10d2e79ca7d79"
 
 [[package]]
 name = "paste-impl"
@@ -2122,7 +2194,7 @@ checksum = "069bdb1e05adc7a8990dce9cc75370895fbe4e3d58b9b73bf1aee56359344a55"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2167,7 +2239,7 @@ dependencies = [
  "proc-macro-error-attr",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
  "version_check",
 ]
 
@@ -2190,9 +2262,9 @@ checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.51"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d727cae5b39d21da60fa540906919ad737832fe0b1c165da3a34d6548c849d6"
+checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
 dependencies = [
  "unicode-ident",
 ]
@@ -2279,9 +2351,9 @@ checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quote"
-version = "1.0.23"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
+checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
 dependencies = [
  "proc-macro2",
 ]
@@ -2386,10 +2458,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "regex"
-version = "1.7.1"
+name = "redox_syscall"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48aaa5748ba571fb95cd2c85c09f629215d3a6ece942baa100950af03a34f733"
+checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "regex"
+version = "1.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b1f693b24f6ac912f4893ef08244d70b6067480d2f1a46e950c9691e6749d1d"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2407,24 +2488,15 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.28"
+version = "0.6.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
-
-[[package]]
-name = "remove_dir_all"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
-dependencies = [
- "winapi",
-]
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "reqwest"
-version = "0.11.14"
+version = "0.11.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21eed90ec8570952d53b772ecf8f206aa1ec9a3d76b2521c56c42973f2d91ee9"
+checksum = "27b71749df584b7f4cac2c426c127a7c785a5106cc98f7a8feb044115f0fa254"
 dependencies = [
  "base64 0.21.0",
  "bytes",
@@ -2476,7 +2548,7 @@ checksum = "44519172358fd6d58656c86ab8e7fbc9e1490c3e8f14d35ed78ca0dd07403c9f"
 dependencies = [
  "byteorder",
  "num-traits",
- "paste 1.0.11",
+ "paste 1.0.12",
 ]
 
 [[package]]
@@ -2492,9 +2564,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.21"
+version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342"
+checksum = "d4a36c42d1873f9a77c53bde094f9664d9891bc604a45b4798fd2c389ed12e5b"
 
 [[package]]
 name = "rustc_version"
@@ -2506,12 +2578,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls-pemfile"
-version = "0.2.1"
+name = "rustix"
+version = "0.37.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5eebeaeb360c87bfb72e84abdb3447159c0eaececf1bef2aecd65a8be949d1c9"
+checksum = "2aae838e49b3d63e9274e1c01833cc8139d3fec468c3b84688c628f44b1ae11d"
 dependencies = [
- "base64 0.13.1",
+ "bitflags",
+ "errno",
+ "io-lifetimes",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d194b56d58803a43635bdc398cd17e383d6f71f9182b9a192c127ca42494a59b"
+dependencies = [
+ "base64 0.21.0",
 ]
 
 [[package]]
@@ -2528,15 +2614,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.12"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b4b9743ed687d4b4bcedf9ff5eaa7398495ae14e61cba0a295704edbc7decde"
-
-[[package]]
-name = "safemem"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef703b7cb59335eae2eb93ceb664c0eb7ea6bf567079d843e09420219668e072"
+checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
 
 [[package]]
 name = "schannel"
@@ -2569,7 +2649,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2586,9 +2666,9 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "scratch"
-version = "1.0.3"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddccb15bcce173023b3fedd9436f882a0739b8dfb45e4f6b6002bee5929f61b2"
+checksum = "1792db035ce95be60c3f8853017b3999209281c24e2ba5bc8e59bf97a0c590c1"
 
 [[package]]
 name = "security-framework"
@@ -2615,15 +2695,15 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.16"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58bc9567378fc7690d6b2addae4e60ac2eeea07becb2c64b9f218b53865cba2a"
+checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
 
 [[package]]
 name = "serde"
-version = "1.0.152"
+version = "1.0.159"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb7d1f0d3021d347a83e556fc4683dea2ea09d87bccdf88ff5c12545d89d5efb"
+checksum = "3c04e8343c3daeec41f58990b9d77068df31209f2af111e059e9fe9646693065"
 dependencies = [
  "serde_derive",
 ]
@@ -2648,13 +2728,13 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.152"
+version = "1.0.159"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af487d118eecd09402d70a5d72551860e788df87b464af30e5ea6a38c75c541e"
+checksum = "4c614d17805b093df4b147b51339e7e44bf05ef59fba1e45d83500bcfb4d8585"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.13",
 ]
 
 [[package]]
@@ -2665,14 +2745,14 @@ checksum = "1dbab34ca63057a1f15280bdf3c39f2b1eb1b54c17e98360e511637aef7418c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.93"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cad406b69c91885b5107daf2c29572f6c8cdb3c66826821e286c533490c0bc76"
+checksum = "d721eca97ac802aa7777b701877c8004d950fc142651367300d21c1cc0194744"
 dependencies = [
  "itoa",
  "ryu",
@@ -2681,13 +2761,13 @@ dependencies = [
 
 [[package]]
 name = "serde_repr"
-version = "0.1.10"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a5ec9fa74a20ebbe5d9ac23dac1fc96ba0ecfe9f50f2843b52e537b10fbcb4e"
+checksum = "bcec881020c684085e55a25f7fd888954d56609ef363479dc5a1305eb0d40cab"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.13",
 ]
 
 [[package]]
@@ -2700,17 +2780,6 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
-]
-
-[[package]]
-name = "sha-1"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5058ada175748e33390e40e872bd0fe59a19f265d0158daa551c5a88a76009c"
-dependencies = [
- "cfg-if 1.0.0",
- "cpufeatures",
- "digest 0.10.6",
 ]
 
 [[package]]
@@ -2777,13 +2846,13 @@ dependencies = [
 
 [[package]]
 name = "simplelog"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48dfff04aade74dd495b007c831cd6f4e0cee19c344dd9dc0884c0289b70a786"
+checksum = "acee08041c5de3d5048c8b3f6f13fafb3026b24ba43c6a695a0c76179b844369"
 dependencies = [
  "log",
  "termcolor",
- "time 0.3.19",
+ "time 0.3.20",
 ]
 
 [[package]]
@@ -2806,9 +2875,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.4.7"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02e2d2db9033d13a1567121ddd7a095ee144db4e1ca1b1bda3419bc0da294ebd"
+checksum = "64a4a911eed85daf18834cfaa86a79b7d266ff93ff5ba14005426219480ed662"
 dependencies = [
  "libc",
  "winapi",
@@ -2853,7 +2922,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2864,9 +2933,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.107"
+version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2874,15 +2943,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "synstructure"
-version = "0.12.6"
+name = "syn"
+version = "2.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
+checksum = "4c9da457c5285ac1f936ebd076af6dac17a61cfe7826f2076b4d015cf47bc8ec"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -2908,16 +2976,15 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.3.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
+checksum = "b9fbec84f381d5795b08656e4912bec604d162bff9291d6189a78f4c8ab87998"
 dependencies = [
  "cfg-if 1.0.0",
  "fastrand",
- "libc",
- "redox_syscall",
- "remove_dir_all",
- "winapi",
+ "redox_syscall 0.3.5",
+ "rustix",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -2946,22 +3013,22 @@ checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
 
 [[package]]
 name = "thiserror"
-version = "1.0.38"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a9cd18aa97d5c45c6603caea1da6628790b37f7a34b6ca89522331c5180fed0"
+checksum = "978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.38"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fb327af4685e4d03fa8cbcf1716380da910eeb2bb8be417e7f9fd3fb164f36f"
+checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.13",
 ]
 
 [[package]]
@@ -2987,9 +3054,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.19"
+version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53250a3b3fed8ff8fd988587d8925d26a83ac3845d9e03b220b37f34c2b8d6c2"
+checksum = "cd0cbfecb4d19b5ea75bb31ad904eb5b9fa13f21079c3b92017ebdf4999a5890"
 dependencies = [
  "itoa",
  "libc",
@@ -3007,9 +3074,9 @@ checksum = "2e153e1f1acaef8acc537e68b44906d2db6436e2b35ac2c6b42640fff91f00fd"
 
 [[package]]
 name = "time-macros"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a460aeb8de6dcb0f381e1ee05f1cd56fcf5a5f6eb8187ff3d8f0b11078d38b7c"
+checksum = "fd80a657e71da814b8e5d60d3374fc6d35045062245d80224748ae522dd76f36"
 dependencies = [
  "time-core",
 ]
@@ -3031,14 +3098,13 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.25.0"
+version = "1.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8e00990ebabbe4c14c08aca901caed183ecd5c09562a12c824bb53d3c3fd3af"
+checksum = "d0de47a4eecbe11f498978a9b29d792f0d2692d1dd003650c24c76510e3bc001"
 dependencies = [
  "autocfg",
  "bytes",
  "libc",
- "memchr",
  "mio",
  "num_cpus",
  "parking_lot 0.12.1",
@@ -3046,18 +3112,18 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys 0.42.0",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "1.8.2"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d266c00fde287f55d3f1c3e96c500c362a2b8c695076ec180f27918820bc6df8"
+checksum = "61a573bdc87985e9d6ddeed1b3d864e8a302c847e40d647746df2f1de209d1ce"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.13",
 ]
 
 [[package]]
@@ -3111,9 +3177,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.17.2"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f714dd15bead90401d77e04243611caec13726c2408afd5b31901dfcdcb3b181"
+checksum = "54319c93411147bced34cb5609a80e0a8e44c5999c93903a81cd866630ec0bfd"
 dependencies = [
  "futures-util",
  "log",
@@ -3206,7 +3272,7 @@ checksum = "4017f8f45139870ca7e672686113917c71c7a6e02d4924eda67186083c03081a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -3280,9 +3346,9 @@ checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
 
 [[package]]
 name = "tungstenite"
-version = "0.17.3"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e27992fd6a8c29ee7eef28fc78349aa244134e10ad447ce3b9f0ac0ed0fa4ce0"
+checksum = "30ee6ab729cd4cf0fd55218530c4522ed30b7b6081752839b68fcec8d0960788"
 dependencies = [
  "base64 0.13.1",
  "byteorder",
@@ -3291,19 +3357,10 @@ dependencies = [
  "httparse",
  "log",
  "rand 0.8.5",
- "sha-1",
+ "sha1",
  "thiserror",
  "url",
  "utf-8",
-]
-
-[[package]]
-name = "twoway"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59b11b2b5241ba34be09c3cc85a36e56e48f9888862e19cedf23336d35316ed1"
-dependencies = [
- "memchr",
 ]
 
 [[package]]
@@ -3341,15 +3398,15 @@ dependencies = [
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.10"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d54675592c1dbefd78cbd98db9bacd89886e1ca50692a0692baefffdeb92dd58"
+checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.6"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
+checksum = "e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4"
 
 [[package]]
 name = "unicode-normalization"
@@ -3371,12 +3428,6 @@ name = "unicode-width"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
-
-[[package]]
-name = "unicode-xid"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
 
 [[package]]
 name = "untrusted"
@@ -3477,9 +3528,9 @@ dependencies = [
 
 [[package]]
 name = "warp"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed7b8be92646fc3d18b06147664ebc5f48d222686cb11a8755e561a735aacc6d"
+checksum = "27e1a710288f0f91a98dd8a74f05b76a10768db245ce183edf64dc1afdc3016c"
 dependencies = [
  "async-compression",
  "bytes",
@@ -3491,7 +3542,7 @@ dependencies = [
  "log",
  "mime",
  "mime_guess",
- "multipart",
+ "multiparty",
  "percent-encoding",
  "pin-project",
  "rustls-pemfile",
@@ -3558,7 +3609,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
  "wasm-bindgen-shared",
 ]
 
@@ -3592,7 +3643,7 @@ checksum = "2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -3688,18 +3739,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
+dependencies = [
+ "windows-targets 0.48.0",
+]
+
+[[package]]
 name = "windows-sys"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -3708,65 +3768,131 @@ version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.0",
 ]
 
 [[package]]
 name = "windows-targets"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e2522491fbfcd58cc84d47aeb2958948c4b8982e9a2d8a2a35bbaed431390e7"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b1eb6f0cd7c80c79759c929114ef071b87354ce476d9d94271031c0497adfd5"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.0",
+ "windows_aarch64_msvc 0.48.0",
+ "windows_i686_gnu 0.48.0",
+ "windows_i686_msvc 0.48.0",
+ "windows_x86_64_gnu 0.48.0",
+ "windows_x86_64_gnullvm 0.48.0",
+ "windows_x86_64_msvc 0.48.0",
 ]
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c9864e83243fdec7fc9c5444389dcbbfd258f745e7853198f365e3c4968a608"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c8b1b673ffc16c47a9ff48570a9d85e25d265735c503681332589af6253c6c7"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de3887528ad530ba7bdbb1faa8275ec7a1155a45ffa57c37993960277145d640"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf4d1122317eddd6ff351aa852118a2418ad4214e6613a50e0191f7004372605"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1040f221285e17ebccbc2591ffdc2d44ee1f9186324dd3e84e99ac68d699c45"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "628bfdf232daa22b0d64fdb62b09fcc36bb01f05a3939e20ab73aaf9470d0463"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "447660ad36a13288b1db4d4248e857b510e8c3a225c822ba4fb748c0aafecffd"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
 
 [[package]]
 name = "winreg"
@@ -3803,14 +3929,13 @@ dependencies = [
 
 [[package]]
 name = "zeroize_derive"
-version = "1.3.3"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44bf07cb3e50ea2003396695d58bf46bc9887a1f362260446fad6bc4e79bd36c"
+checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
- "synstructure",
+ "syn 2.0.13",
 ]
 
 [[package]]

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,8 +10,8 @@ use clap::{crate_description, crate_version, Arg, Command};
 use log::error;
 
 use subcommands::{
-    archive, check, execution_results_summary, extract_slice, latest_block_summary, trie_compact,
-    unsparse, Error,
+    archive, check, execution_results_summary, extract_slice, latest_block_summary,
+    purge_signatures, trie_compact, unsparse, Error,
 };
 
 const LOGGING: &str = "logging";
@@ -22,6 +22,7 @@ enum DisplayOrder {
     ExecutionResults,
     ExtractSlice,
     LatestBlock,
+    PurgeSignatures,
     TrieCompact,
     Unsparse,
 }
@@ -39,6 +40,9 @@ fn cli() -> Command<'static> {
         .subcommand(extract_slice::command(DisplayOrder::ExtractSlice as usize))
         .subcommand(latest_block_summary::command(
             DisplayOrder::LatestBlock as usize,
+        ))
+        .subcommand(purge_signatures::command(
+            DisplayOrder::PurgeSignatures as usize,
         ))
         .subcommand(trie_compact::command(DisplayOrder::TrieCompact as usize))
         .subcommand(unsparse::command(DisplayOrder::Unsparse as usize))
@@ -87,6 +91,7 @@ fn main() {
         latest_block_summary::COMMAND_NAME => {
             latest_block_summary::run(matches).map_err(Error::from)
         }
+        purge_signatures::COMMAND_NAME => purge_signatures::run(matches).map_err(Error::from),
         trie_compact::COMMAND_NAME => trie_compact::run(matches).map_err(Error::from),
         unsparse::COMMAND_NAME => unsparse::run(matches).map_err(Error::from),
         _ => unreachable!("{} should be handled above", subcommand_name),

--- a/src/subcommands.rs
+++ b/src/subcommands.rs
@@ -3,6 +3,7 @@ pub mod check;
 pub mod execution_results_summary;
 pub mod extract_slice;
 pub mod latest_block_summary;
+pub mod purge_signatures;
 pub mod trie_compact;
 pub mod unsparse;
 
@@ -13,6 +14,7 @@ use check::Error as CheckError;
 use execution_results_summary::Error as ExecutionResultsSummaryError;
 use extract_slice::Error as ExtractSliceError;
 use latest_block_summary::Error as LatestBlockSummaryError;
+use purge_signatures::Error as PurgeSignaturesError;
 use trie_compact::Error as TrieCompactError;
 use unsparse::Error as UnsparseError;
 
@@ -30,6 +32,8 @@ pub enum Error {
     ExtractSlice(#[from] ExtractSliceError),
     #[error("Latest block summary command failed: {0}")]
     LatestBlockSummary(#[from] LatestBlockSummaryError),
+    #[error("Purge signatures failed: {0}")]
+    PurgeSignatures(#[from] PurgeSignaturesError),
     #[error("Trie compact failed: {0}")]
     TrieCompact(#[from] TrieCompactError),
     #[error("Unsparse failed: {0}")]

--- a/src/subcommands/execution_results_summary/tests.rs
+++ b/src/subcommands/execution_results_summary/tests.rs
@@ -22,10 +22,7 @@ use crate::{
         },
         Error,
     },
-    test_utils::{
-        mock_block_header, mock_deploy_hash, mock_deploy_metadata, success_execution_result,
-        LmdbTestFixture, MockBlockHeader,
-    },
+    test_utils::{self, LmdbTestFixture, MockBlockHeader},
 };
 
 static OUT_DIR: Lazy<TempDir> = Lazy::new(|| tempfile::tempdir().unwrap());
@@ -156,7 +153,7 @@ fn different_execution_results_stats_feed() {
     for i in 1..4 {
         let mut execution_results = vec![];
         for _ in 0..(10 * i) {
-            execution_results.push(success_execution_result());
+            execution_results.push(test_utils::success_execution_result());
         }
         bincode_sizes.push(bincode::serialized_size(&execution_results).unwrap() as usize);
         bytesrepr_sizes.push(chunk_count_after_partition(
@@ -190,7 +187,7 @@ fn identical_execution_results_stats_feed() {
     for _ in 1..4 {
         let mut execution_results = vec![];
         for _ in 0..10 {
-            execution_results.push(success_execution_result());
+            execution_results.push(test_utils::success_execution_result());
         }
         bincode_sizes.push(bincode::serialized_size(&execution_results).unwrap() as usize);
         bytesrepr_sizes.push(chunk_count_after_partition(
@@ -236,9 +233,12 @@ fn execution_results_stats_should_succeed() {
     );
     let out_file_path = OUT_DIR.as_ref().join("execution_results_summary.json");
 
-    let deploy_hashes: Vec<DeployHash> = (0..DEPLOY_COUNT as u8).map(mock_deploy_hash).collect();
-    let block_headers: Vec<(BlockHash, MockBlockHeader)> =
-        (0..BLOCK_COUNT as u8).map(mock_block_header).collect();
+    let deploy_hashes: Vec<DeployHash> = (0..DEPLOY_COUNT as u8)
+        .map(test_utils::mock_deploy_hash)
+        .collect();
+    let block_headers: Vec<(BlockHash, MockBlockHeader)> = (0..BLOCK_COUNT as u8)
+        .map(test_utils::mock_block_header)
+        .collect();
     let mut block_bodies = vec![];
     let mut block_body_deploy_map: Vec<Vec<usize>> = vec![];
     block_bodies.push(BlockBody::new(vec![
@@ -253,10 +253,10 @@ fn execution_results_stats_should_succeed() {
     block_body_deploy_map.push(vec![2, 3]);
 
     let deploy_metadatas = vec![
-        mock_deploy_metadata(slice::from_ref(&block_headers[0].0)),
-        mock_deploy_metadata(&[block_headers[0].0, block_headers[1].0]),
-        mock_deploy_metadata(&[block_headers[1].0, block_headers[2].0]),
-        mock_deploy_metadata(&[block_headers[0].0, block_headers[2].0]),
+        test_utils::mock_deploy_metadata(slice::from_ref(&block_headers[0].0)),
+        test_utils::mock_deploy_metadata(&[block_headers[0].0, block_headers[1].0]),
+        test_utils::mock_deploy_metadata(&[block_headers[1].0, block_headers[2].0]),
+        test_utils::mock_deploy_metadata(&[block_headers[0].0, block_headers[2].0]),
     ];
 
     let env = &fixture.env;
@@ -336,7 +336,7 @@ fn execution_results_summary_invalid_key_should_fail() {
 
     let env = &fixture.env;
     if let Ok(mut txn) = env.begin_rw_txn() {
-        let (_, block_header) = mock_block_header(0);
+        let (_, block_header) = test_utils::mock_block_header(0);
         let bogus_hash = [0u8; 1];
         // Insert a block header in the database with a key that can't be
         // deserialized.
@@ -369,8 +369,8 @@ fn execution_results_summary_parsing_should_fail() {
     );
     let out_file_path = OUT_DIR.as_ref().join("parsing.json");
 
-    let deploy_hash = mock_deploy_hash(0);
-    let (block_hash, block_header) = mock_block_header(0);
+    let deploy_hash = test_utils::mock_deploy_hash(0);
+    let (block_hash, block_header) = test_utils::mock_block_header(0);
     let block_body = BlockBody::new(vec![deploy_hash]);
 
     let env = &fixture.env;

--- a/src/subcommands/purge_signatures.rs
+++ b/src/subcommands/purge_signatures.rs
@@ -4,7 +4,7 @@ mod signatures;
 #[cfg(test)]
 mod tests;
 
-use std::path::Path;
+use std::{collections::BTreeSet, path::Path};
 
 use bincode::Error as BincodeError;
 use casper_node::types::BlockHash;
@@ -97,7 +97,7 @@ pub fn command(display_order: usize) -> Command<'static> {
 
 pub fn run(matches: &ArgMatches) -> Result<(), Error> {
     let path = Path::new(matches.value_of(DB_PATH).expect("should have db-path arg"));
-    let weak_finality_block_list: Vec<u64> = matches
+    let weak_finality_block_list: BTreeSet<u64> = matches
         .value_of(WEAK_FINALITY)
         .map(|height_list| height_list.split(','))
         .map(|height_str| {
@@ -109,7 +109,7 @@ pub fn run(matches: &ArgMatches) -> Result<(), Error> {
         })
         .map(|list| list.collect())
         .unwrap_or_default();
-    let no_finality_block_list: Vec<u64> = matches
+    let no_finality_block_list: BTreeSet<u64> = matches
         .value_of(NO_FINALITY)
         .map(|height_list| height_list.split(','))
         .map(|height_str| {

--- a/src/subcommands/purge_signatures.rs
+++ b/src/subcommands/purge_signatures.rs
@@ -1,0 +1,125 @@
+pub(crate) mod block_signatures;
+mod purge;
+mod signatures;
+#[cfg(test)]
+mod tests;
+
+use std::path::Path;
+
+use bincode::Error as BincodeError;
+use casper_node::types::BlockHash;
+use casper_types::EraId;
+use clap::{Arg, ArgMatches, Command};
+use lmdb::Error as LmdbError;
+use thiserror::Error as ThisError;
+
+pub const COMMAND_NAME: &str = "purge-signatures";
+const DB_PATH: &str = "db-path";
+const NO_FINALITY: &str = "no-finality";
+const WEAK_FINALITY: &str = "weak-finality";
+
+/// Errors encountered when operating on the storage database.
+#[derive(Debug, ThisError)]
+pub enum Error {
+    #[error("Block list is empty")]
+    EmptyBlockList,
+    #[error("No blocks found in the block header database")]
+    EmptyDatabase,
+    /// Database operation error.
+    #[error("Error operating the database: {0}")]
+    Database(#[from] LmdbError),
+    #[error("Found duplicate block header with height {0}")]
+    DuplicateBlock(u64),
+    /// Parsing error on entry in the block header database.
+    #[error("Error parsing block header with hash {0}: {1}")]
+    HeaderParsing(BlockHash, BincodeError),
+    #[error("Missing switch block with weights for era {0}")]
+    MissingEraWeights(EraId),
+    /// Serialization error for an entry in the signatures database.
+    #[error("Error serializing block signatures for block hash {0}: {1}")]
+    Serialize(BlockHash, BincodeError),
+    /// Parsing error on entry at index in the signatures database.
+    #[error("Error parsing block signatures for block hash {0}: {1}")]
+    SignaturesParsing(BlockHash, BincodeError),
+}
+
+enum DisplayOrder {
+    DbPath,
+    WeakFinality,
+    NoFinality,
+}
+
+pub fn command(display_order: usize) -> Command<'static> {
+    Command::new(COMMAND_NAME)
+        .display_order(display_order)
+        .about(
+            "Purges the signatures for a given block list from a storage \
+            database.",
+        )
+        .arg(
+            Arg::new(DB_PATH)
+                .display_order(DisplayOrder::DbPath as usize)
+                .required(true)
+                .short('d')
+                .long(DB_PATH)
+                .takes_value(true)
+                .value_name("DB_PATH")
+                .help("Path of the directory with the `storage.lmdb` file."),
+        )
+        .arg(
+            Arg::new(WEAK_FINALITY)
+                .display_order(DisplayOrder::WeakFinality as usize)
+                .required_unless_present(NO_FINALITY)
+                .short('w')
+                .long(WEAK_FINALITY)
+                .takes_value(true)
+                .value_name("BLOCK_HEIGHT_LIST")
+                .help(
+                    "List of block heights separated by ',' for which \
+                    signatures will be stripped until weak finality is \
+                    reached.",
+                ),
+        )
+        .arg(
+            Arg::new(NO_FINALITY)
+                .display_order(DisplayOrder::NoFinality as usize)
+                .required_unless_present(WEAK_FINALITY)
+                .short('n')
+                .long(NO_FINALITY)
+                .takes_value(true)
+                .value_name("BLOCK_HEIGHT_LIST")
+                .help(
+                    "List of block heights separated by ',' for which \
+                    all signatures will be stripped.",
+                ),
+        )
+}
+
+pub fn run(matches: &ArgMatches) -> Result<(), Error> {
+    let path = Path::new(matches.value_of(DB_PATH).expect("should have db-path arg"));
+    let weak_finality_block_list: Vec<u64> = matches
+        .value_of(WEAK_FINALITY)
+        .map(|height_list| height_list.split(','))
+        .map(|height_str| {
+            height_str.map(|height| {
+                height
+                    .parse()
+                    .unwrap_or_else(|_| panic!("{height} is not a valid block height"))
+            })
+        })
+        .map(|list| list.collect())
+        .unwrap_or_default();
+    let no_finality_block_list: Vec<u64> = matches
+        .value_of(NO_FINALITY)
+        .map(|height_list| height_list.split(','))
+        .map(|height_str| {
+            height_str.map(|height| {
+                height
+                    .parse()
+                    .unwrap_or_else(|_| panic!("{height} is not a valid block height"))
+            })
+        })
+        .map(|list| list.collect())
+        .unwrap_or_default();
+    purge::purge_signatures(path, weak_finality_block_list, no_finality_block_list)
+}

--- a/src/subcommands/purge_signatures/block_signatures.rs
+++ b/src/subcommands/purge_signatures/block_signatures.rs
@@ -1,0 +1,44 @@
+use std::{
+    collections::BTreeMap,
+    fmt::{self, Display, Formatter},
+};
+
+use casper_node::types::BlockHash;
+use casper_types::{EraId, PublicKey, Signature};
+use serde::{Deserialize, Serialize};
+
+/// A storage representation of finality signatures with the associated block
+/// hash. This structure had to be copied over from the node codebase because
+/// it is not publicly accessible through the API.
+#[derive(Clone, Debug, Default, PartialOrd, Ord, Hash, Serialize, Deserialize, Eq, PartialEq)]
+pub(crate) struct BlockSignatures {
+    /// The block hash for a given block.
+    pub(crate) block_hash: BlockHash,
+    /// The era id for the given set of finality signatures.
+    pub(crate) era_id: EraId,
+    /// The signatures associated with the block hash.
+    pub(crate) proofs: BTreeMap<PublicKey, Signature>,
+}
+
+#[cfg(test)]
+impl BlockSignatures {
+    pub(crate) fn new(block_hash: BlockHash, era_id: EraId) -> Self {
+        Self {
+            block_hash,
+            era_id,
+            proofs: Default::default(),
+        }
+    }
+}
+
+impl Display for BlockSignatures {
+    fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
+        write!(
+            formatter,
+            "block signatures for hash: {} in era_id: {} with {} proofs",
+            self.block_hash,
+            self.era_id,
+            self.proofs.len()
+        )
+    }
+}

--- a/src/subcommands/purge_signatures/purge.rs
+++ b/src/subcommands/purge_signatures/purge.rs
@@ -281,7 +281,7 @@ pub(crate) fn purge_signatures_for_blocks(
                 WriteFlags::default(),
             )?;
         } else {
-            info!("Couldn't strip signatures for block {block_hash} at height {block_height}");
+            warn!("Couldn't strip signatures for block {block_hash} at height {block_height}");
         }
         progress_tracker.advance_by(1);
     }

--- a/src/subcommands/purge_signatures/purge.rs
+++ b/src/subcommands/purge_signatures/purge.rs
@@ -1,0 +1,266 @@
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    path::Path,
+};
+
+use casper_hashing::Digest;
+use casper_node::types::{BlockHash, BlockHeader};
+use casper_types::{EraId, PublicKey, U512};
+use lmdb::{Cursor, Database, Environment, Transaction, WriteFlags};
+use log::{error, info, warn};
+
+use crate::common::{
+    db::{self, BlockHeaderDatabase, BlockMetadataDatabase, Database as _, STORAGE_FILE_NAME},
+    lmdb_utils,
+    progress::ProgressTracker,
+};
+
+use super::{block_signatures::BlockSignatures, signatures::strip_signatures, Error};
+
+/// Structure to hold lookup information for a set of block headers.
+#[derive(Default)]
+pub(crate) struct Indices {
+    /// Hold the hash and the header of a block keyed by its height.
+    pub(crate) heights: BTreeMap<u64, (BlockHash, BlockHeader)>,
+    /// Hold the hash of switch blocks keyed by the era for which they hold
+    /// the weights.
+    pub(crate) switch_blocks: BTreeMap<EraId, BlockHash>,
+}
+
+/// Cache-like structure to store the validator weights for an era.
+#[derive(Default)]
+pub(crate) struct EraWeights {
+    era_id: EraId,
+    weights: BTreeMap<PublicKey, U512>,
+}
+
+impl EraWeights {
+    /// Update the internal structure to hold the validator weights for
+    /// the era given as input.
+    pub(crate) fn refresh_weights_for_era<T: Transaction>(
+        &mut self,
+        txn: &T,
+        db: Database,
+        indices: &Indices,
+        era_id: EraId,
+    ) -> Result<(), Error> {
+        // If we already have the requested era, exit early.
+        if self.era_id == era_id {
+            return Ok(());
+        }
+        // Get the required era's associated switch block.
+        let switch_block_hash = indices
+            .switch_blocks
+            .get(&era_id)
+            .ok_or_else(|| Error::MissingEraWeights(era_id))?;
+        // Deserialize it.
+        let switch_block_header: BlockHeader =
+            bincode::deserialize(txn.get(db, &switch_block_hash)?)
+                .map_err(|bincode_err| Error::HeaderParsing(*switch_block_hash, bincode_err))?;
+        // Get the weights.
+        let weights = switch_block_header
+            .next_era_validator_weights()
+            .cloned()
+            .ok_or_else(|| Error::MissingEraWeights(era_id))?;
+        self.weights = weights;
+        self.era_id = era_id;
+        Ok(())
+    }
+
+    #[cfg(test)]
+    pub(crate) fn era_id(&self) -> EraId {
+        self.era_id
+    }
+
+    #[cfg(test)]
+    pub(crate) fn weights_mut(&mut self) -> &mut BTreeMap<PublicKey, U512> {
+        &mut self.weights
+    }
+}
+
+/// Creates a collection of indices to store lookup information for a given
+/// list of block heights.
+pub(crate) fn initialize_indices(
+    env: &Environment,
+    needed_heights: &BTreeSet<u64>,
+) -> Result<Indices, Error> {
+    let mut indices = Indices::default();
+    let txn = env.begin_ro_txn()?;
+    let header_db = unsafe { txn.open_db(Some(BlockHeaderDatabase::db_name()))? };
+
+    let mut maybe_progress_tracker = match lmdb_utils::entry_count(&txn, header_db).ok() {
+        Some(entry_count) => Some(
+            ProgressTracker::new(
+                entry_count,
+                Box::new(|completion| info!("Header database parsing {}% complete...", completion)),
+            )
+            .map_err(|_| Error::EmptyDatabase)?,
+        ),
+        None => {
+            info!("Skipping progress tracking for header database parsing");
+            None
+        }
+    };
+
+    {
+        // Iterate through all block headers.
+        let mut cursor = txn.open_ro_cursor(header_db)?;
+        for (raw_key, raw_value) in cursor.iter() {
+            if let Some(progress_tracker) = maybe_progress_tracker.as_mut() {
+                progress_tracker.advance_by(1);
+            }
+            // Deserialize the block hash.
+            let block_hash: BlockHash = match Digest::try_from(raw_key) {
+                Ok(digest) => digest.into(),
+                Err(digest_parsing_err) => {
+                    error!("Skipping block header because of invalid hash {raw_key:?}: {digest_parsing_err}");
+                    continue;
+                }
+            };
+            // Deserialize the header.
+            let block_header: BlockHeader = bincode::deserialize(raw_value)
+                .map_err(|bincode_err| Error::HeaderParsing(block_hash, bincode_err))?;
+            let block_height = block_header.height();
+            // We store all switch block hashes keyed by the era for which they
+            // hold the weights.
+            if block_header.is_switch_block() {
+                let _ = indices
+                    .switch_blocks
+                    .insert(block_header.era_id().successor(), block_hash);
+            }
+            // If this block is on our list, store its hash and header in the
+            // indices. We store the header to avoid looking it up again in the
+            // future since we know we will need it and we expect
+            // `needed_heights` to be a relatively small list.
+            if needed_heights.contains(&block_height)
+                && indices
+                    .heights
+                    .insert(block_height, (block_hash, block_header))
+                    .is_some()
+            {
+                return Err(Error::DuplicateBlock(block_height));
+            };
+        }
+    }
+    txn.commit()?;
+    Ok(indices)
+}
+
+/// Purges finality signatures from a database for all blocks of heights found
+/// in `heights_to_visit`.
+///
+/// If the `full_purge` flag is set, all the signatures for the associated
+/// block will be purged by deleting the record in the block signatures
+/// database.
+///
+/// If the `full_purge` flag is not set, signatures will be purged until the
+/// remaining set of signatures gives the block weak but not strict finality.
+/// If this is not possible for that block given its signature set and the era
+/// weights, it is skipped and a message is logged.
+pub(crate) fn purge_signatures_for_blocks(
+    env: &Environment,
+    indices: &Indices,
+    heights_to_visit: BTreeSet<u64>,
+    full_purge: bool,
+) -> Result<(), Error> {
+    let mut txn = env.begin_rw_txn()?;
+    let header_db = unsafe { txn.open_db(Some(BlockHeaderDatabase::db_name()))? };
+    let signatures_db = unsafe { txn.open_db(Some(BlockMetadataDatabase::db_name()))? };
+
+    let mut era_weights = EraWeights::default();
+
+    let mut progress_tracker = ProgressTracker::new(
+        heights_to_visit.len(),
+        Box::new(if full_purge {
+            |completion| {
+                info!(
+                    "Signature purging to no finality {}% complete...",
+                    completion
+                )
+            }
+        } else {
+            |completion| {
+                info!(
+                    "Signature purging to weak finality {}% complete...",
+                    completion
+                )
+            }
+        }),
+    )
+    .map_err(|_| Error::EmptyBlockList)?;
+
+    for height in heights_to_visit {
+        // Get the block hash and header from the indices for this height.
+        let (block_hash, block_header) = match indices.heights.get(&height) {
+            Some((block_hash, block_header)) => {
+                // We don't strip signatures for the genesis block.
+                if block_header.era_id().is_genesis() {
+                    warn!("Cannot strip signatures for genesis block");
+                    progress_tracker.advance_by(1);
+                    continue;
+                }
+                (block_hash, block_header)
+            }
+            None => {
+                // Skip blocks which are not in the database.
+                warn!("Block at height {height} is not present in the database");
+                progress_tracker.advance_by(1);
+                continue;
+            }
+        };
+        let block_height = block_header.height();
+        let era_id = block_header.era_id();
+        // Make sure we have the correct era weights for this block before
+        // trying to strip any signatures.
+        era_weights.refresh_weights_for_era(&txn, header_db, indices, era_id)?;
+
+        let raw_signatures = txn.get(signatures_db, &block_hash)?;
+        let mut block_signatures: BlockSignatures = bincode::deserialize(raw_signatures)
+            .map_err(|bincode_err| Error::SignaturesParsing(*block_hash, bincode_err))?;
+
+        if full_purge {
+            // Delete the record completely from the database.
+            txn.del(signatures_db, &block_hash, None)?;
+        } else if strip_signatures(&mut block_signatures, &era_weights.weights) {
+            // Serialize the remaining signatures and overwrite the database
+            // entry.
+            let serialized_signatures = bincode::serialize(&block_signatures)
+                .map_err(|bincode_err| Error::Serialize(*block_hash, bincode_err))?;
+            txn.put(
+                signatures_db,
+                &block_hash,
+                &serialized_signatures,
+                WriteFlags::default(),
+            )?;
+        } else {
+            info!("Couldn't strip signatures for block {block_hash} at height {block_height}");
+        }
+        progress_tracker.advance_by(1);
+    }
+    txn.commit()?;
+    Ok(())
+}
+
+pub fn purge_signatures<P: AsRef<Path>>(
+    db_path: P,
+    weak_finality_block_list: Vec<u64>,
+    no_finality_block_list: Vec<u64>,
+) -> Result<(), Error> {
+    let storage_path = db_path.as_ref().join(STORAGE_FILE_NAME);
+    let env = db::db_env(storage_path)?;
+    let heights_to_visit: BTreeSet<u64> = weak_finality_block_list
+        .iter()
+        .chain(no_finality_block_list.iter())
+        .copied()
+        .collect();
+    let indices = initialize_indices(&env, &heights_to_visit)?;
+    if !weak_finality_block_list.is_empty() {
+        let weak_finality_heights = weak_finality_block_list.iter().copied().collect();
+        purge_signatures_for_blocks(&env, &indices, weak_finality_heights, false)?;
+    }
+    if !no_finality_block_list.is_empty() {
+        let no_finality_heights = no_finality_block_list.iter().copied().collect();
+        purge_signatures_for_blocks(&env, &indices, no_finality_heights, true)?;
+    }
+    Ok(())
+}

--- a/src/subcommands/purge_signatures/signatures.rs
+++ b/src/subcommands/purge_signatures/signatures.rs
@@ -43,7 +43,7 @@ pub(super) fn strip_signatures(
     }
     let mut accumulated_sigs: BTreeSet<&PublicKey> = Default::default();
     let mut accumulated_weight = U512::zero();
-    // Start from the smalles signatures and add them to our pool until weak
+    // Start from the smallest signatures and add them to our pool until weak
     // finality is reached.
     for (weight, key) in inverse_map
         .iter()
@@ -79,7 +79,7 @@ pub(super) fn strip_signatures(
     if !is_weak_finality(accumulated_weight, total_weight) {
         return false;
     }
-    // Keep only the signatures.
+    // Keep only the accumulated signatures.
     signatures
         .proofs
         .retain(|key, _| accumulated_sigs.contains(key));

--- a/src/subcommands/purge_signatures/signatures.rs
+++ b/src/subcommands/purge_signatures/signatures.rs
@@ -1,4 +1,4 @@
-use std::collections::{btree_map::Entry, BTreeMap, BTreeSet};
+use std::collections::{BTreeMap, BTreeSet};
 
 use casper_types::{PublicKey, U512};
 
@@ -34,12 +34,7 @@ pub(super) fn strip_signatures(
     // Store the signature keys sorted by their respective weight.
     let mut inverse_map: BTreeMap<U512, Vec<&PublicKey>> = BTreeMap::default();
     for (key, weight) in weights.iter() {
-        match inverse_map.entry(*weight) {
-            Entry::Vacant(vacant_entry) => {
-                vacant_entry.insert(vec![key]);
-            }
-            Entry::Occupied(mut occupied_entry) => occupied_entry.get_mut().push(key),
-        }
+        inverse_map.entry(*weight).or_default().push(key);
     }
     let mut accumulated_sigs: BTreeSet<&PublicKey> = Default::default();
     let mut accumulated_weight = U512::zero();

--- a/src/subcommands/purge_signatures/signatures.rs
+++ b/src/subcommands/purge_signatures/signatures.rs
@@ -1,0 +1,281 @@
+use std::collections::{btree_map::Entry, BTreeMap, BTreeSet};
+
+use casper_types::{PublicKey, U512};
+
+use super::block_signatures::BlockSignatures;
+
+// Returns whether the cumulative `weight` exceeds the weak finality threshold
+// for a `total` weight.
+fn is_weak_finality(weight: U512, total: U512) -> bool {
+    weight * 3 > total
+}
+
+// Returns whether the cumulative `weight` exceeds the strict finality
+// threshold for a `total` weight.
+fn is_strict_finality(weight: U512, total: U512) -> bool {
+    weight * 3 > total * 2
+}
+
+/// Removes signatures from the given `BlockSignatures` structure until weak
+/// but not strict finality is reached and returns whether the operation
+/// succeeded. There are signature and weights combinations for which it is
+/// not possible to reach a state where weak but not strict finality is
+/// reached.
+pub(super) fn strip_signatures(
+    signatures: &mut BlockSignatures,
+    weights: &BTreeMap<PublicKey, U512>,
+) -> bool {
+    // Calculate the total weight.
+    let total_weight: U512 = weights
+        .iter()
+        .map(|(_, weight)| weight)
+        .fold(U512::zero(), |acc, weight| acc + *weight);
+
+    // Store the signature keys sorted by their respective weight.
+    let mut inverse_map: BTreeMap<U512, Vec<&PublicKey>> = BTreeMap::default();
+    for (key, weight) in weights.iter() {
+        match inverse_map.entry(*weight) {
+            Entry::Vacant(vacant_entry) => {
+                vacant_entry.insert(vec![key]);
+            }
+            Entry::Occupied(mut occupied_entry) => occupied_entry.get_mut().push(key),
+        }
+    }
+    let mut accumulated_sigs: BTreeSet<&PublicKey> = Default::default();
+    let mut accumulated_weight = U512::zero();
+    // Start from the smalles signatures and add them to our pool until weak
+    // finality is reached.
+    for (weight, key) in inverse_map
+        .iter()
+        .flat_map(|(weight, keys)| keys.iter().map(move |key| (weight, *key)))
+    {
+        if signatures.proofs.contains_key(key) {
+            accumulated_weight += *weight;
+            accumulated_sigs.insert(key);
+
+            if is_weak_finality(accumulated_weight, total_weight) {
+                break;
+            }
+        }
+    }
+    // If our pool of signatures is over the strict finality threshold, start
+    // removing the smallest ones until we no longer have strict finality.
+    while is_strict_finality(accumulated_weight, total_weight) {
+        if accumulated_sigs.is_empty() {
+            return false;
+        }
+        let popped_sig = accumulated_sigs.pop_first().unwrap();
+        let popped_sig_weight = weights.get(popped_sig).unwrap();
+        accumulated_weight -= *popped_sig_weight;
+    }
+    // At this point, if we don't have weak finality it means it is not
+    // possible to create a subset of signatures with weak but not strict
+    // finality. This might be because:
+    // - the block didn't have weak finality to begin with
+    // - there is a super-majority from a very large signature weight (over 2/3
+    //   of the weights)
+    // - it would have been possible with the given weights, but there are
+    //   missing signatures from our set in `BlockSignatures`
+    if !is_weak_finality(accumulated_weight, total_weight) {
+        return false;
+    }
+    // Keep only the signatures.
+    signatures
+        .proofs
+        .retain(|key, _| accumulated_sigs.contains(key));
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use casper_types::{PublicKey, Signature, U512};
+
+    use crate::{
+        subcommands::purge_signatures::{
+            block_signatures::BlockSignatures,
+            signatures::{is_strict_finality, is_weak_finality, strip_signatures},
+        },
+        test_utils::KEYS,
+    };
+
+    #[test]
+    fn weak_finality() {
+        assert!(!is_weak_finality(1.into(), 3.into()));
+        assert!(!is_weak_finality(0.into(), 1_000.into()));
+        assert!(!is_weak_finality(10.into(), 1_000.into()));
+        assert!(!is_weak_finality(333_333.into(), 1_000_000.into()));
+
+        assert!(is_weak_finality(333_334.into(), 1_000_000.into()));
+        assert!(is_weak_finality(666_667.into(), 1_000_000.into()));
+        assert!(is_weak_finality(1_000_000.into(), 1_000_000.into()));
+    }
+
+    #[test]
+    fn strict_finality() {
+        assert!(!is_strict_finality(2.into(), 3.into()));
+        assert!(!is_strict_finality(0.into(), 1000.into()));
+        assert!(!is_strict_finality(10.into(), 1000.into()));
+        assert!(!is_strict_finality(333_333.into(), 1_000_000.into()));
+        assert!(!is_strict_finality(333_334.into(), 1_000_000.into()));
+        assert!(!is_strict_finality(666_666.into(), 1_000_000.into()));
+
+        assert!(is_strict_finality(666_667.into(), 1_000_000.into()));
+        assert!(is_strict_finality(900.into(), 1000.into()));
+        assert!(is_strict_finality(1000.into(), 1000.into()));
+    }
+
+    #[test]
+    fn strip_signatures_progressive() {
+        let mut block_signatures = BlockSignatures::default();
+        // Create signatures for keys [1..4].
+        block_signatures
+            .proofs
+            .insert(KEYS[0].clone(), Signature::System);
+        block_signatures
+            .proofs
+            .insert(KEYS[1].clone(), Signature::System);
+        block_signatures
+            .proofs
+            .insert(KEYS[2].clone(), Signature::System);
+        block_signatures
+            .proofs
+            .insert(KEYS[3].clone(), Signature::System);
+
+        let mut weights: BTreeMap<PublicKey, U512> = BTreeMap::default();
+        // Add weights for keys [1..4].
+        weights.insert(KEYS[0].clone(), 100.into());
+        weights.insert(KEYS[1].clone(), 200.into());
+        weights.insert(KEYS[2].clone(), 300.into());
+        weights.insert(KEYS[3].clone(), 400.into());
+
+        assert!(strip_signatures(&mut block_signatures, &weights));
+        // Signatures from keys [1..3] have a cumulative weight of 600/1000,
+        // so signature from key 4 should have been purged.
+        assert!(block_signatures.proofs.contains_key(&KEYS[0]));
+        assert!(block_signatures.proofs.contains_key(&KEYS[1]));
+        assert!(block_signatures.proofs.contains_key(&KEYS[2]));
+        assert!(!block_signatures.proofs.contains_key(&KEYS[3]));
+    }
+
+    #[test]
+    fn strip_signatures_equal_weights() {
+        let mut block_signatures = BlockSignatures::default();
+        // Create signatures for keys [1..2].
+        block_signatures
+            .proofs
+            .insert(KEYS[0].clone(), Signature::System);
+        block_signatures
+            .proofs
+            .insert(KEYS[1].clone(), Signature::System);
+
+        let mut weights: BTreeMap<PublicKey, U512> = BTreeMap::default();
+        // Add weights for keys [1..2].
+        weights.insert(KEYS[0].clone(), 500.into());
+        weights.insert(KEYS[1].clone(), 500.into());
+
+        assert!(strip_signatures(&mut block_signatures, &weights));
+        // Any of the signatures has half the weight, so only one should have
+        // been kept.
+        assert_eq!(block_signatures.proofs.len(), 1);
+    }
+
+    #[test]
+    fn strip_signatures_one_small_three_large() {
+        let mut block_signatures = BlockSignatures::default();
+        // Create signatures for keys [1..4].
+        block_signatures
+            .proofs
+            .insert(KEYS[0].clone(), Signature::System);
+        block_signatures
+            .proofs
+            .insert(KEYS[1].clone(), Signature::System);
+        block_signatures
+            .proofs
+            .insert(KEYS[2].clone(), Signature::System);
+        block_signatures
+            .proofs
+            .insert(KEYS[3].clone(), Signature::System);
+
+        let mut weights: BTreeMap<PublicKey, U512> = BTreeMap::default();
+        // Add weights for keys [1..4].
+        weights.insert(KEYS[0].clone(), 1.into());
+        weights.insert(KEYS[1].clone(), 333.into());
+        weights.insert(KEYS[2].clone(), 333.into());
+        weights.insert(KEYS[3].clone(), 333.into());
+
+        assert!(strip_signatures(&mut block_signatures, &weights));
+        // Any of the signatures [2..4] has a third of the weight, so one of
+        // them plus the first signature with a weight of 1 make weak but not
+        // strict finality.
+        assert!(block_signatures.proofs.contains_key(&KEYS[0]));
+        assert_eq!(block_signatures.proofs.len(), 2);
+    }
+
+    #[test]
+    fn strip_signatures_split_weights() {
+        let mut block_signatures = BlockSignatures::default();
+        // Create signatures for keys [1..3].
+        block_signatures
+            .proofs
+            .insert(KEYS[0].clone(), Signature::System);
+        block_signatures
+            .proofs
+            .insert(KEYS[1].clone(), Signature::System);
+        block_signatures
+            .proofs
+            .insert(KEYS[2].clone(), Signature::System);
+
+        let mut weights: BTreeMap<PublicKey, U512> = BTreeMap::default();
+        // Add weights for keys [1..3].
+        weights.insert(KEYS[0].clone(), 333.into());
+        weights.insert(KEYS[1].clone(), 333.into());
+        weights.insert(KEYS[2].clone(), 333.into());
+
+        assert!(strip_signatures(&mut block_signatures, &weights));
+        // Any 2 signatures have a cumulative weight of 666/999, or 2/3 of the
+        // weight, so 1 of the 3 signatures should have been purged.
+        assert_eq!(block_signatures.proofs.len(), 2);
+    }
+
+    #[test]
+    fn strip_signatures_one_key_has_strict_finality() {
+        let mut block_signatures = BlockSignatures::default();
+        // Create signatures for keys [1..3].
+        block_signatures
+            .proofs
+            .insert(KEYS[0].clone(), Signature::System);
+        block_signatures
+            .proofs
+            .insert(KEYS[1].clone(), Signature::System);
+        block_signatures
+            .proofs
+            .insert(KEYS[2].clone(), Signature::System);
+
+        let mut weights: BTreeMap<PublicKey, U512> = BTreeMap::default();
+        // Add weights for keys [1..3].
+        weights.insert(KEYS[0].clone(), 100.into());
+        weights.insert(KEYS[1].clone(), 200.into());
+        weights.insert(KEYS[2].clone(), 700.into());
+        // It is not possible to construct a weak but not strict finality set
+        // of signatures with the given weights.
+        assert!(!strip_signatures(&mut block_signatures, &weights));
+    }
+
+    #[test]
+    fn strip_signatures_single_key() {
+        let mut block_signatures = BlockSignatures::default();
+        // Create a signature for key 1.
+        block_signatures
+            .proofs
+            .insert(KEYS[0].clone(), Signature::System);
+
+        let mut weights: BTreeMap<PublicKey, U512> = BTreeMap::default();
+        // Add a weight for key 1.
+        weights.insert(KEYS[0].clone(), 1000.into());
+        // It is not possible to construct a weak but not strict finality set
+        // of signatures with a single weight.
+        assert!(!strip_signatures(&mut block_signatures, &weights));
+    }
+}

--- a/src/subcommands/purge_signatures/tests.rs
+++ b/src/subcommands/purge_signatures/tests.rs
@@ -332,7 +332,7 @@ fn era_weights() {
         );
         assert!(!era_weights.weights_mut().contains_key(&KEYS[0]));
 
-        // Try to update the weights for a inexistent switch block.
+        // Try to update the weights for a nonexistent switch block.
         let expected_missing_era_id = switch_block_headers[1].1.era_id.successor().successor();
         match era_weights.refresh_weights_for_era(&txn, db, &indices, expected_missing_era_id) {
             Err(Error::MissingEraWeights(actual_missing_era_id)) => {
@@ -638,7 +638,7 @@ fn purge_signatures_should_work() {
         assert!(block_2_sigs.proofs.contains_key(&KEYS[0]));
         assert!(!block_2_sigs.proofs.contains_key(&KEYS[1]));
 
-        // Block 2 should be the same as before.
+        // Block 3 should be the same as before.
         let block_3_sigs = get_sigs_from_db(&txn, &fixture, &block_headers[2].0);
         assert!(block_3_sigs.proofs.contains_key(&KEYS[0]));
         assert!(block_3_sigs.proofs.contains_key(&KEYS[1]));

--- a/src/subcommands/purge_signatures/tests.rs
+++ b/src/subcommands/purge_signatures/tests.rs
@@ -23,7 +23,7 @@ fn get_sigs_from_db<T: Transaction>(
     let serialized_sigs = txn
         .get(*fixture.db(Some("block_metadata")).unwrap(), block_hash)
         .unwrap();
-    let block_sigs: BlockSignatures = bincode::deserialize(&serialized_sigs).unwrap();
+    let block_sigs: BlockSignatures = bincode::deserialize(serialized_sigs).unwrap();
     assert_eq!(block_sigs.block_hash, *block_hash);
     block_sigs
 }
@@ -61,22 +61,22 @@ fn indices_initialization() {
     let env = &fixture.env;
     // Insert the blocks into the database.
     if let Ok(mut txn) = env.begin_rw_txn() {
-        for i in 0..BLOCK_COUNT {
+        for (block_hash, block_header) in block_headers.iter().take(BLOCK_COUNT) {
             // Store the block header.
             txn.put(
                 *fixture.db(Some("block_header")).unwrap(),
-                &block_headers[i].0,
-                &bincode::serialize(&block_headers[i].1).unwrap(),
+                block_hash,
+                &bincode::serialize(&block_header).unwrap(),
                 WriteFlags::empty(),
             )
             .unwrap();
         }
-        for i in 0..SWITCH_BLOCK_COUNT {
+        for (block_hash, block_header) in switch_block_headers.iter().take(SWITCH_BLOCK_COUNT) {
             // Store the switch block header.
             txn.put(
                 *fixture.db(Some("block_header")).unwrap(),
-                &switch_block_headers[i].0,
-                &bincode::serialize(&switch_block_headers[i].1).unwrap(),
+                block_hash,
+                &bincode::serialize(block_header).unwrap(),
                 WriteFlags::empty(),
             )
             .unwrap();
@@ -173,12 +173,12 @@ fn era_weights() {
     let env = &fixture.env;
     // Insert the blocks into the database.
     if let Ok(mut txn) = env.begin_rw_txn() {
-        for i in 0..SWITCH_BLOCK_COUNT {
+        for (block_hash, block_header) in switch_block_headers.iter().take(SWITCH_BLOCK_COUNT) {
             // Store the switch block header.
             txn.put(
                 *fixture.db(Some("block_header")).unwrap(),
-                &switch_block_headers[i].0,
-                &bincode::serialize(&switch_block_headers[i].1).unwrap(),
+                block_hash,
+                &bincode::serialize(block_header).unwrap(),
                 WriteFlags::empty(),
             )
             .unwrap();
@@ -388,12 +388,12 @@ fn purge_signatures_should_work() {
             )
             .unwrap();
         }
-        for i in 0..SWITCH_BLOCK_COUNT {
+        for (block_hash, block_header) in switch_block_headers.iter().take(SWITCH_BLOCK_COUNT) {
             // Store the switch block header.
             txn.put(
                 *fixture.db(Some("block_header")).unwrap(),
-                &switch_block_headers[i].0,
-                &bincode::serialize(&switch_block_headers[i].1).unwrap(),
+                block_hash,
+                &bincode::serialize(block_header).unwrap(),
                 WriteFlags::empty(),
             )
             .unwrap();
@@ -560,12 +560,12 @@ fn purge_signatures_bad_input() {
             )
             .unwrap();
         }
-        for i in 0..SWITCH_BLOCK_COUNT {
+        for (block_hash, block_header) in switch_block_headers.iter().take(SWITCH_BLOCK_COUNT) {
             // Store the switch block header.
             txn.put(
                 *fixture.db(Some("block_header")).unwrap(),
-                &switch_block_headers[i].0,
-                &bincode::serialize(&switch_block_headers[i].1).unwrap(),
+                block_hash,
+                &bincode::serialize(block_header).unwrap(),
                 WriteFlags::empty(),
             )
             .unwrap();

--- a/src/subcommands/purge_signatures/tests.rs
+++ b/src/subcommands/purge_signatures/tests.rs
@@ -1,0 +1,612 @@
+use std::collections::BTreeSet;
+
+use casper_node::types::BlockHash;
+use casper_types::{Signature, U512};
+use lmdb::{Error as LmdbError, Transaction, WriteFlags};
+
+use crate::{
+    subcommands::purge_signatures::{
+        block_signatures::BlockSignatures,
+        purge::{initialize_indices, purge_signatures_for_blocks, EraWeights},
+        Error,
+    },
+    test_utils::{self, LmdbTestFixture, MockBlockHeader, MockSwitchBlockHeader, KEYS},
+};
+
+// Gets and deserializes a `BlockSignatures` structure from the block
+// signatures database.
+fn get_sigs_from_db<T: Transaction>(
+    txn: &T,
+    fixture: &LmdbTestFixture,
+    block_hash: &BlockHash,
+) -> BlockSignatures {
+    let serialized_sigs = txn
+        .get(*fixture.db(Some("block_metadata")).unwrap(), block_hash)
+        .unwrap();
+    let block_sigs: BlockSignatures = bincode::deserialize(&serialized_sigs).unwrap();
+    assert_eq!(block_sigs.block_hash, *block_hash);
+    block_sigs
+}
+
+#[test]
+fn indices_initialization() {
+    const BLOCK_COUNT: usize = 4;
+    const SWITCH_BLOCK_COUNT: usize = 2;
+
+    let fixture = LmdbTestFixture::new(vec!["block_header"], None);
+
+    // Create mock block headers.
+    let mut block_headers: Vec<(BlockHash, MockBlockHeader)> = (0..BLOCK_COUNT as u8)
+        .map(test_utils::mock_block_header)
+        .collect();
+    // Set an era and height for each one.
+    block_headers[0].1.era_id = 10.into();
+    block_headers[0].1.height = 100;
+    block_headers[1].1.era_id = 10.into();
+    block_headers[1].1.height = 200;
+    block_headers[2].1.era_id = 20.into();
+    block_headers[2].1.height = 300;
+    block_headers[3].1.era_id = 20.into();
+    block_headers[3].1.height = 400;
+    // Create mock switch blocks for each era.
+    let mut switch_block_headers: Vec<(BlockHash, MockSwitchBlockHeader)> = (0..BLOCK_COUNT as u8)
+        .map(test_utils::mock_switch_block_header)
+        .collect();
+    // Set an appropriate era and height for each one.
+    switch_block_headers[0].1.era_id = block_headers[0].1.era_id - 1;
+    switch_block_headers[0].1.height = 80;
+    switch_block_headers[1].1.era_id = block_headers[2].1.era_id - 1;
+    switch_block_headers[1].1.height = 280;
+
+    let env = &fixture.env;
+    // Insert the blocks into the database.
+    if let Ok(mut txn) = env.begin_rw_txn() {
+        for i in 0..BLOCK_COUNT {
+            // Store the block header.
+            txn.put(
+                *fixture.db(Some("block_header")).unwrap(),
+                &block_headers[i].0,
+                &bincode::serialize(&block_headers[i].1).unwrap(),
+                WriteFlags::empty(),
+            )
+            .unwrap();
+        }
+        for i in 0..SWITCH_BLOCK_COUNT {
+            // Store the switch block header.
+            txn.put(
+                *fixture.db(Some("block_header")).unwrap(),
+                &switch_block_headers[i].0,
+                &bincode::serialize(&switch_block_headers[i].1).unwrap(),
+                WriteFlags::empty(),
+            )
+            .unwrap();
+        }
+        txn.commit().unwrap();
+    };
+
+    let indices = initialize_indices(env, &BTreeSet::from([100, 200, 300])).unwrap();
+    // Make sure we have the relevant blocks in the indices.
+    assert_eq!(
+        indices.heights.get(&block_headers[0].1.height).unwrap().0,
+        block_headers[0].0
+    );
+    assert_eq!(
+        indices.heights.get(&block_headers[1].1.height).unwrap().0,
+        block_headers[1].0
+    );
+    assert_eq!(
+        indices.heights.get(&block_headers[2].1.height).unwrap().0,
+        block_headers[2].0
+    );
+    // And that the irrelevant ones are not included.
+    assert!(!indices.heights.contains_key(&block_headers[3].1.height));
+    // Make sure we got all the switch blocks.
+    assert_eq!(
+        *indices
+            .switch_blocks
+            .get(&block_headers[0].1.era_id)
+            .unwrap(),
+        switch_block_headers[0].0
+    );
+    assert_eq!(
+        *indices
+            .switch_blocks
+            .get(&block_headers[2].1.era_id)
+            .unwrap(),
+        switch_block_headers[1].0
+    );
+
+    // Test for a header with a height which we already have in the db.
+    let (duplicate_hash, mut duplicate_header) = test_utils::mock_block_header(4);
+    duplicate_header.height = block_headers[0].1.height;
+    if let Ok(mut txn) = env.begin_rw_txn() {
+        // Store the header with duplicated height.
+        txn.put(
+            *fixture.db(Some("block_header")).unwrap(),
+            &duplicate_hash,
+            &bincode::serialize(&duplicate_header).unwrap(),
+            WriteFlags::empty(),
+        )
+        .unwrap();
+        txn.commit().unwrap();
+    };
+
+    match initialize_indices(env, &BTreeSet::from([100, 200, 300])) {
+        Err(Error::DuplicateBlock(height)) => assert_eq!(height, block_headers[0].1.height),
+        _ => panic!("Unexpected error"),
+    }
+}
+
+#[test]
+fn era_weights() {
+    const SWITCH_BLOCK_COUNT: usize = 2;
+
+    let fixture = LmdbTestFixture::new(vec!["block_header"], None);
+    // Create mock switch block headers.
+    let mut switch_block_headers: Vec<(BlockHash, MockSwitchBlockHeader)> = (0..SWITCH_BLOCK_COUNT
+        as u8)
+        .map(test_utils::mock_switch_block_header)
+        .collect();
+    // Set an era and height for each one.
+    switch_block_headers[0].1.era_id = 10.into();
+    switch_block_headers[0].1.height = 80;
+    // Insert some weight for the next era weights.
+    switch_block_headers[0]
+        .1
+        .era_end
+        .as_mut()
+        .unwrap()
+        .next_era_validator_weights
+        .insert(KEYS[0].clone(), 100.into());
+    // Set an era and height for each one.
+    switch_block_headers[1].1.era_id = 20.into();
+    switch_block_headers[1].1.height = 280;
+    // Insert some weight for the next era weights.
+    switch_block_headers[1]
+        .1
+        .era_end
+        .as_mut()
+        .unwrap()
+        .next_era_validator_weights
+        .insert(KEYS[1].clone(), 100.into());
+
+    let env = &fixture.env;
+    // Insert the blocks into the database.
+    if let Ok(mut txn) = env.begin_rw_txn() {
+        for i in 0..SWITCH_BLOCK_COUNT {
+            // Store the switch block header.
+            txn.put(
+                *fixture.db(Some("block_header")).unwrap(),
+                &switch_block_headers[i].0,
+                &bincode::serialize(&switch_block_headers[i].1).unwrap(),
+                WriteFlags::empty(),
+            )
+            .unwrap();
+        }
+        txn.commit().unwrap();
+    };
+    let indices = initialize_indices(env, &BTreeSet::from([80])).unwrap();
+    let mut era_weights = EraWeights::default();
+    if let Ok(txn) = env.begin_ro_txn() {
+        let db = env.open_db(Some("block_header")).unwrap();
+        // Try to update the weights for the first switch block.
+        assert!(era_weights
+            .refresh_weights_for_era(
+                &txn,
+                db,
+                &indices,
+                switch_block_headers[0].1.era_id.successor()
+            )
+            .is_ok());
+        assert_eq!(
+            era_weights.era_id(),
+            switch_block_headers[0].1.era_id.successor()
+        );
+        assert_eq!(
+            *era_weights.weights_mut().get(&KEYS[0]).unwrap(),
+            U512::from(100)
+        );
+        assert!(!era_weights.weights_mut().contains_key(&KEYS[1]));
+
+        // Try to update the weights for the second switch block.
+        assert!(era_weights
+            .refresh_weights_for_era(
+                &txn,
+                db,
+                &indices,
+                switch_block_headers[1].1.era_id.successor()
+            )
+            .is_ok());
+        assert_eq!(
+            era_weights.era_id(),
+            switch_block_headers[1].1.era_id.successor()
+        );
+        assert_eq!(
+            *era_weights.weights_mut().get(&KEYS[1]).unwrap(),
+            U512::from(100)
+        );
+        assert!(!era_weights.weights_mut().contains_key(&KEYS[0]));
+
+        // Try to update the weights for the second switch block again.
+        assert!(era_weights
+            .refresh_weights_for_era(
+                &txn,
+                db,
+                &indices,
+                switch_block_headers[1].1.era_id.successor()
+            )
+            .is_ok());
+        assert_eq!(
+            era_weights.era_id(),
+            switch_block_headers[1].1.era_id.successor()
+        );
+        assert_eq!(
+            *era_weights.weights_mut().get(&KEYS[1]).unwrap(),
+            U512::from(100)
+        );
+        assert!(!era_weights.weights_mut().contains_key(&KEYS[0]));
+
+        // Try to update the weights for a inexistent switch block.
+        let expected_missing_era_id = switch_block_headers[1].1.era_id.successor().successor();
+        match era_weights.refresh_weights_for_era(&txn, db, &indices, expected_missing_era_id) {
+            Err(Error::MissingEraWeights(actual_missing_era_id)) => {
+                assert_eq!(expected_missing_era_id, actual_missing_era_id)
+            }
+            _ => panic!("Unexpected failure"),
+        }
+        txn.commit().unwrap();
+    };
+
+    if let Ok(mut txn) = env.begin_rw_txn() {
+        // Delete the weights for the first switch block in the db.
+        switch_block_headers[0].1.era_end = None;
+        txn.put(
+            *fixture.db(Some("block_header")).unwrap(),
+            &switch_block_headers[0].0,
+            &bincode::serialize(&switch_block_headers[0].1).unwrap(),
+            WriteFlags::empty(),
+        )
+        .unwrap();
+        txn.commit().unwrap();
+    };
+    if let Ok(txn) = env.begin_ro_txn() {
+        let db = env.open_db(Some("block_header")).unwrap();
+        let expected_missing_era_id = switch_block_headers[0].1.era_id.successor();
+        // Make sure we get an error when the block has no weights.
+        match era_weights.refresh_weights_for_era(&txn, db, &indices, expected_missing_era_id) {
+            Err(Error::MissingEraWeights(actual_missing_era_id)) => {
+                assert_eq!(expected_missing_era_id, actual_missing_era_id)
+            }
+            _ => panic!("Unexpected failure"),
+        }
+        txn.commit().unwrap();
+    };
+}
+
+#[test]
+fn purge_signatures_should_work() {
+    const BLOCK_COUNT: usize = 4;
+    const SWITCH_BLOCK_COUNT: usize = 2;
+
+    let fixture = LmdbTestFixture::new(vec!["block_header", "block_metadata"], None);
+    // Create mock block headers.
+    let mut block_headers: Vec<(BlockHash, MockBlockHeader)> = (0..BLOCK_COUNT as u8)
+        .map(test_utils::mock_block_header)
+        .collect();
+    // Set an era and height for each one.
+    block_headers[0].1.era_id = 10.into();
+    block_headers[0].1.height = 100;
+    block_headers[1].1.era_id = 10.into();
+    block_headers[1].1.height = 200;
+    block_headers[2].1.era_id = 20.into();
+    block_headers[2].1.height = 300;
+    block_headers[3].1.era_id = 20.into();
+    block_headers[3].1.height = 400;
+    // Create mock block signatures.
+    let mut block_signatures: Vec<BlockSignatures> = block_headers
+        .iter()
+        .map(|(block_hash, header)| BlockSignatures::new(*block_hash, header.era_id))
+        .collect();
+    // Create mock switch block headers.
+    let mut switch_block_headers: Vec<(BlockHash, MockSwitchBlockHeader)> = (0..SWITCH_BLOCK_COUNT
+        as u8)
+        .map(test_utils::mock_switch_block_header)
+        .collect();
+    // Set an appropriate era and height for switch block 1.
+    switch_block_headers[0].1.era_id = block_headers[0].1.era_id - 1;
+    switch_block_headers[0].1.height = 80;
+    // Add weights for this switch block (500, 500).
+    switch_block_headers[0]
+        .1
+        .insert_key_weight(KEYS[0].clone(), 500.into());
+    switch_block_headers[0]
+        .1
+        .insert_key_weight(KEYS[1].clone(), 500.into());
+
+    // Add keys and signatures for block 1.
+    block_signatures[0]
+        .proofs
+        .insert(KEYS[0].clone(), Signature::System);
+    block_signatures[0]
+        .proofs
+        .insert(KEYS[1].clone(), Signature::System);
+    // Add keys and signatures for block 2.
+    block_signatures[1]
+        .proofs
+        .insert(KEYS[0].clone(), Signature::System);
+
+    // Set an appropriate era and height for switch block 2.
+    switch_block_headers[1].1.era_id = block_headers[2].1.era_id - 1;
+    switch_block_headers[1].1.height = 280;
+    // Add weights for this switch block (300, 300, 400).
+    switch_block_headers[1]
+        .1
+        .insert_key_weight(KEYS[0].clone(), 300.into());
+    switch_block_headers[1]
+        .1
+        .insert_key_weight(KEYS[1].clone(), 300.into());
+    switch_block_headers[1]
+        .1
+        .insert_key_weight(KEYS[2].clone(), 400.into());
+
+    // Add keys and signatures for block 3.
+    block_signatures[2]
+        .proofs
+        .insert(KEYS[0].clone(), Signature::System);
+    block_signatures[2]
+        .proofs
+        .insert(KEYS[1].clone(), Signature::System);
+    block_signatures[2]
+        .proofs
+        .insert(KEYS[2].clone(), Signature::System);
+    // Add keys and signatures for block 4.
+    block_signatures[3]
+        .proofs
+        .insert(KEYS[0].clone(), Signature::System);
+    block_signatures[3]
+        .proofs
+        .insert(KEYS[2].clone(), Signature::System);
+
+    let env = &fixture.env;
+    // Insert the blocks and signatures into the database.
+    if let Ok(mut txn) = env.begin_rw_txn() {
+        for i in 0..BLOCK_COUNT {
+            // Store the block header.
+            txn.put(
+                *fixture.db(Some("block_header")).unwrap(),
+                &block_headers[i].0,
+                &bincode::serialize(&block_headers[i].1).unwrap(),
+                WriteFlags::empty(),
+            )
+            .unwrap();
+            // Store the signatures.
+            txn.put(
+                *fixture.db(Some("block_metadata")).unwrap(),
+                &block_headers[i].0,
+                &bincode::serialize(&block_signatures[i]).unwrap(),
+                WriteFlags::empty(),
+            )
+            .unwrap();
+        }
+        for i in 0..SWITCH_BLOCK_COUNT {
+            // Store the switch block header.
+            txn.put(
+                *fixture.db(Some("block_header")).unwrap(),
+                &switch_block_headers[i].0,
+                &bincode::serialize(&switch_block_headers[i].1).unwrap(),
+                WriteFlags::empty(),
+            )
+            .unwrap();
+        }
+        txn.commit().unwrap();
+    };
+
+    let indices = initialize_indices(env, &BTreeSet::from([100, 200, 300, 400])).unwrap();
+
+    // Purge signatures for blocks 1, 2 and 3 to weak finality.
+    assert!(
+        purge_signatures_for_blocks(env, &indices, BTreeSet::from([100, 200, 300]), false).is_ok()
+    );
+    if let Ok(txn) = env.begin_ro_txn() {
+        let block_1_sigs = get_sigs_from_db(&txn, &fixture, &block_headers[0].0);
+        // For block 1, any of the 2 signatures will be fine (500/1000), but
+        // not both.
+        assert!(
+            (block_1_sigs.proofs.contains_key(&KEYS[0])
+                && !block_1_sigs.proofs.contains_key(&KEYS[1]))
+                || (!block_1_sigs.proofs.contains_key(&KEYS[0])
+                    && block_1_sigs.proofs.contains_key(&KEYS[1]))
+        );
+
+        // Block 2 only had the first signature, which already meets the
+        // requirements (500/1000).
+        let block_2_sigs = get_sigs_from_db(&txn, &fixture, &block_headers[1].0);
+        assert!(block_2_sigs.proofs.contains_key(&KEYS[0]));
+        assert!(!block_2_sigs.proofs.contains_key(&KEYS[1]));
+
+        // Block 3 had all the keys (300, 300, 400), so it should have kept
+        // the first 2.
+        let block_3_sigs = get_sigs_from_db(&txn, &fixture, &block_headers[2].0);
+        assert!(block_3_sigs.proofs.contains_key(&KEYS[0]));
+        assert!(block_3_sigs.proofs.contains_key(&KEYS[1]));
+        assert!(!block_3_sigs.proofs.contains_key(&KEYS[2]));
+
+        // Block 4 had signatures for keys 1 (300) and 3 (400), but it was not
+        // included in the purge list, so it should have kept both.
+        let block_4_sigs = get_sigs_from_db(&txn, &fixture, &block_headers[3].0);
+        assert!(block_4_sigs.proofs.contains_key(&KEYS[0]));
+        assert!(!block_4_sigs.proofs.contains_key(&KEYS[1]));
+        assert!(block_4_sigs.proofs.contains_key(&KEYS[2]));
+        txn.commit().unwrap();
+    };
+
+    // Purge signatures for blocks 1 and 4 to no finality.
+    assert!(purge_signatures_for_blocks(env, &indices, BTreeSet::from([100, 400]), true).is_ok());
+    if let Ok(txn) = env.begin_ro_txn() {
+        // We should have no record for the signatures of block 1.
+        match txn.get(
+            *fixture.db(Some("block_metadata")).unwrap(),
+            &block_headers[0].0,
+        ) {
+            Err(LmdbError::NotFound) => {}
+            other => panic!("Unexpected search result: {other:?}"),
+        }
+
+        // Block 2 should be the same as before.
+        let block_2_sigs = get_sigs_from_db(&txn, &fixture, &block_headers[1].0);
+        assert!(block_2_sigs.proofs.contains_key(&KEYS[0]));
+        assert!(!block_2_sigs.proofs.contains_key(&KEYS[1]));
+
+        // Block 2 should be the same as before.
+        let block_3_sigs = get_sigs_from_db(&txn, &fixture, &block_headers[2].0);
+        assert!(block_3_sigs.proofs.contains_key(&KEYS[0]));
+        assert!(block_3_sigs.proofs.contains_key(&KEYS[1]));
+        assert!(!block_3_sigs.proofs.contains_key(&KEYS[2]));
+
+        // We should have no record for the signatures of block 4.
+        match txn.get(
+            *fixture.db(Some("block_metadata")).unwrap(),
+            &block_headers[3].0,
+        ) {
+            Err(LmdbError::NotFound) => {}
+            other => panic!("Unexpected search result: {other:?}"),
+        }
+        txn.commit().unwrap();
+    };
+}
+
+#[test]
+fn purge_signatures_bad_input() {
+    const BLOCK_COUNT: usize = 2;
+    const SWITCH_BLOCK_COUNT: usize = 2;
+
+    let fixture = LmdbTestFixture::new(vec!["block_header", "block_metadata"], None);
+    // Create mock block headers.
+    let mut block_headers: Vec<(BlockHash, MockBlockHeader)> = (0..BLOCK_COUNT as u8)
+        .map(test_utils::mock_block_header)
+        .collect();
+    // Set an era and height for block 1.
+    block_headers[0].1.era_id = 10.into();
+    block_headers[0].1.height = 100;
+    // Set an era and height for block 2.
+    block_headers[1].1.era_id = 20.into();
+    block_headers[1].1.height = 200;
+    // Create mock block signatures.
+    let mut block_signatures: Vec<BlockSignatures> = block_headers
+        .iter()
+        .map(|(block_hash, header)| BlockSignatures::new(*block_hash, header.era_id))
+        .collect();
+    // Create mock switch block headers.
+    let mut switch_block_headers: Vec<(BlockHash, MockSwitchBlockHeader)> = (0..SWITCH_BLOCK_COUNT
+        as u8)
+        .map(test_utils::mock_switch_block_header)
+        .collect();
+    // Set an appropriate era and height for switch block 1.
+    switch_block_headers[0].1.era_id = block_headers[0].1.era_id - 1;
+    switch_block_headers[0].1.height = 80;
+    // Add weights for this switch block (700, 300).
+    switch_block_headers[0]
+        .1
+        .insert_key_weight(KEYS[0].clone(), 700.into());
+    switch_block_headers[0]
+        .1
+        .insert_key_weight(KEYS[1].clone(), 300.into());
+
+    // Add keys and signatures for block 1.
+    block_signatures[0]
+        .proofs
+        .insert(KEYS[0].clone(), Signature::System);
+    block_signatures[0]
+        .proofs
+        .insert(KEYS[1].clone(), Signature::System);
+
+    // Set an appropriate era and height for switch block 2.
+    switch_block_headers[1].1.era_id = block_headers[1].1.era_id - 1;
+    switch_block_headers[1].1.height = 180;
+    // Add weights for this switch block (400, 600).
+    switch_block_headers[1]
+        .1
+        .insert_key_weight(KEYS[0].clone(), 400.into());
+    switch_block_headers[1]
+        .1
+        .insert_key_weight(KEYS[1].clone(), 600.into());
+
+    // Add keys and signatures for block 2.
+    block_signatures[1]
+        .proofs
+        .insert(KEYS[0].clone(), Signature::System);
+    block_signatures[1]
+        .proofs
+        .insert(KEYS[1].clone(), Signature::System);
+
+    let env = &fixture.env;
+    // Insert the blocks and signatures into the database.
+    if let Ok(mut txn) = env.begin_rw_txn() {
+        for i in 0..BLOCK_COUNT {
+            // Store the block header.
+            txn.put(
+                *fixture.db(Some("block_header")).unwrap(),
+                &block_headers[i].0,
+                &bincode::serialize(&block_headers[i].1).unwrap(),
+                WriteFlags::empty(),
+            )
+            .unwrap();
+            // Store the signatures.
+            txn.put(
+                *fixture.db(Some("block_metadata")).unwrap(),
+                &block_headers[i].0,
+                &bincode::serialize(&block_signatures[i]).unwrap(),
+                WriteFlags::empty(),
+            )
+            .unwrap();
+        }
+        for i in 0..SWITCH_BLOCK_COUNT {
+            // Store the switch block header.
+            txn.put(
+                *fixture.db(Some("block_header")).unwrap(),
+                &switch_block_headers[i].0,
+                &bincode::serialize(&switch_block_headers[i].1).unwrap(),
+                WriteFlags::empty(),
+            )
+            .unwrap();
+        }
+        txn.commit().unwrap();
+    };
+
+    let indices = initialize_indices(env, &BTreeSet::from([100])).unwrap();
+    // Purge signatures for blocks 1 and 2 to weak finality.
+    assert!(purge_signatures_for_blocks(env, &indices, BTreeSet::from([100, 200]), false).is_ok());
+    if let Ok(txn) = env.begin_ro_txn() {
+        let block_1_sigs = get_sigs_from_db(&txn, &fixture, &block_headers[0].0);
+        // Block 1 has a super-majority signature (700), so the purge would
+        // have failed and the signatures are untouched.
+        assert!(block_1_sigs.proofs.contains_key(&KEYS[0]));
+        assert!(block_1_sigs.proofs.contains_key(&KEYS[1]));
+
+        let block_2_sigs = get_sigs_from_db(&txn, &fixture, &block_headers[1].0);
+        // Block 2 wasn't in the purge list, so it should be untouched.
+        assert!(block_2_sigs.proofs.contains_key(&KEYS[0]));
+        assert!(block_2_sigs.proofs.contains_key(&KEYS[1]));
+        txn.commit().unwrap();
+    };
+
+    // Overwrite the signatures for block 2 with bogus data.
+    if let Ok(mut txn) = env.begin_rw_txn() {
+        // Store the signatures.
+        txn.put(
+            *fixture.db(Some("block_metadata")).unwrap(),
+            &block_headers[1].0,
+            &bincode::serialize(&[0u8, 1u8, 2u8]).unwrap(),
+            WriteFlags::empty(),
+        )
+        .unwrap();
+        txn.commit().unwrap();
+    };
+
+    let indices = initialize_indices(env, &BTreeSet::from([100, 200])).unwrap();
+    // Purge should fail with a deserialization error.
+    match purge_signatures_for_blocks(env, &indices, BTreeSet::from([100, 200]), false) {
+        Err(Error::SignaturesParsing(block_hash, _)) if block_hash == block_headers[1].0 => {}
+        other => panic!("Unexpected result: {other:?}"),
+    };
+}

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -1,14 +1,36 @@
 #![cfg(test)]
 
-use std::{collections::HashMap, fs::OpenOptions, path::PathBuf};
+use std::{
+    collections::{BTreeMap, HashMap},
+    fs::OpenOptions,
+    path::PathBuf,
+};
 
 use lmdb::{Database as LmdbDatabase, DatabaseFlags, Environment, EnvironmentFlags};
+use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
 use tempfile::{NamedTempFile, TempDir};
 
 use casper_hashing::Digest;
 use casper_node::types::{BlockHash, DeployHash, DeployMetadata, Timestamp};
-use casper_types::{EraId, ExecutionEffect, ExecutionResult, ProtocolVersion};
+use casper_types::{
+    EraId, ExecutionEffect, ExecutionResult, ProtocolVersion, PublicKey, SecretKey, U256, U512,
+};
+
+pub(crate) static KEYS: Lazy<Vec<PublicKey>> = Lazy::new(|| {
+    (0..10)
+        .into_iter()
+        .map(|i| {
+            let u256 = U256::from(i);
+            let mut u256_bytes = [0u8; 32];
+            u256.to_big_endian(&mut u256_bytes);
+            let secret_key =
+                SecretKey::ed25519_from_bytes(u256_bytes).expect("should create secret key");
+            let public_key = PublicKey::from(&secret_key);
+            public_key
+        })
+        .collect()
+});
 
 pub struct LmdbTestFixture {
     pub env: Environment,
@@ -130,6 +152,19 @@ pub(crate) fn mock_block_header(idx: u8) -> (BlockHash, MockBlockHeader) {
     (block_hash, block_header)
 }
 
+pub(crate) fn mock_switch_block_header(idx: u8) -> (BlockHash, MockSwitchBlockHeader) {
+    let mut block_header = MockSwitchBlockHeader::default();
+    let block_hash_digest: Digest = {
+        let mut bytes = [idx; Digest::LENGTH];
+        bytes[Digest::LENGTH - 1] = 255;
+        bytes
+    }
+    .into();
+    let block_hash: BlockHash = block_hash_digest.into();
+    block_header.body_hash = [idx; Digest::LENGTH].into();
+    (block_hash, block_header)
+}
+
 pub(crate) fn mock_deploy_metadata(block_hashes: &[BlockHash]) -> DeployMetadata {
     let mut deploy_metadata = DeployMetadata::default();
     for block_hash in block_hashes {
@@ -145,5 +180,60 @@ pub(crate) fn success_execution_result() -> ExecutionResult {
         effect: ExecutionEffect::default(),
         transfers: vec![],
         cost: 100.into(),
+    }
+}
+
+#[derive(Clone, Debug, Default, PartialOrd, Ord, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub(crate) struct EraReport {
+    equivocators: Vec<PublicKey>,
+    rewards: BTreeMap<PublicKey, u64>,
+    inactive_validators: Vec<PublicKey>,
+}
+
+#[derive(Clone, Default, Ord, PartialOrd, Eq, PartialEq, Hash, Serialize, Deserialize, Debug)]
+pub struct EraEnd {
+    era_report: EraReport,
+    pub next_era_validator_weights: BTreeMap<PublicKey, U512>,
+}
+
+#[derive(Clone, Ord, PartialOrd, Eq, PartialEq, Hash, Serialize, Deserialize, Debug)]
+pub struct MockSwitchBlockHeader {
+    pub parent_hash: BlockHash,
+    pub state_root_hash: Digest,
+    pub body_hash: Digest,
+    pub random_bit: bool,
+    pub accumulated_seed: Digest,
+    pub era_end: Option<EraEnd>,
+    pub timestamp: Timestamp,
+    pub era_id: EraId,
+    pub height: u64,
+    pub protocol_version: ProtocolVersion,
+}
+
+impl MockSwitchBlockHeader {
+    pub fn insert_key_weight(&mut self, key: PublicKey, weight: U512) {
+        let _ = self
+            .era_end
+            .as_mut()
+            .unwrap()
+            .next_era_validator_weights
+            .insert(key, weight);
+    }
+}
+
+impl Default for MockSwitchBlockHeader {
+    fn default() -> Self {
+        Self {
+            parent_hash: Default::default(),
+            state_root_hash: Default::default(),
+            body_hash: Default::default(),
+            random_bit: Default::default(),
+            accumulated_seed: Default::default(),
+            era_end: Some(Default::default()),
+            timestamp: Timestamp::now(),
+            era_id: Default::default(),
+            height: Default::default(),
+            protocol_version: Default::default(),
+        }
     }
 }

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -19,15 +19,13 @@ use casper_types::{
 
 pub(crate) static KEYS: Lazy<Vec<PublicKey>> = Lazy::new(|| {
     (0..10)
-        .into_iter()
         .map(|i| {
             let u256 = U256::from(i);
             let mut u256_bytes = [0u8; 32];
             u256.to_big_endian(&mut u256_bytes);
             let secret_key =
                 SecretKey::ed25519_from_bytes(u256_bytes).expect("should create secret key");
-            let public_key = PublicKey::from(&secret_key);
-            public_key
+            PublicKey::from(&secret_key)
         })
         .collect()
 });


### PR DESCRIPTION
Fixes #33 

This PR adds the `purge-signatures` subcommand. It takes a path to a storage file and lists of block heights for which to purge all signatures or just the required signatures to reach weak but not strict finality.