### PR TITLE
Add `remove-block` subcommand

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -11,7 +11,7 @@ use log::error;
 
 use subcommands::{
     archive, check, execution_results_summary, extract_slice, latest_block_summary,
-    purge_signatures, trie_compact, unsparse, Error,
+    purge_signatures, remove_block, trie_compact, unsparse, Error,
 };
 
 const LOGGING: &str = "logging";
@@ -23,6 +23,7 @@ enum DisplayOrder {
     ExtractSlice,
     LatestBlock,
     PurgeSignatures,
+    RemoveBlock,
     TrieCompact,
     Unsparse,
 }
@@ -44,6 +45,7 @@ fn cli() -> Command<'static> {
         .subcommand(purge_signatures::command(
             DisplayOrder::PurgeSignatures as usize,
         ))
+        .subcommand(remove_block::command(DisplayOrder::RemoveBlock as usize))
         .subcommand(trie_compact::command(DisplayOrder::TrieCompact as usize))
         .subcommand(unsparse::command(DisplayOrder::Unsparse as usize))
         .arg(
@@ -92,6 +94,7 @@ fn main() {
             latest_block_summary::run(matches).map_err(Error::from)
         }
         purge_signatures::COMMAND_NAME => purge_signatures::run(matches).map_err(Error::from),
+        remove_block::COMMAND_NAME => remove_block::run(matches).map_err(Error::from),
         trie_compact::COMMAND_NAME => trie_compact::run(matches).map_err(Error::from),
         unsparse::COMMAND_NAME => unsparse::run(matches).map_err(Error::from),
         _ => unreachable!("{} should be handled above", subcommand_name),

--- a/src/subcommands.rs
+++ b/src/subcommands.rs
@@ -4,6 +4,7 @@ pub mod execution_results_summary;
 pub mod extract_slice;
 pub mod latest_block_summary;
 pub mod purge_signatures;
+pub mod remove_block;
 pub mod trie_compact;
 pub mod unsparse;
 
@@ -15,6 +16,7 @@ use execution_results_summary::Error as ExecutionResultsSummaryError;
 use extract_slice::Error as ExtractSliceError;
 use latest_block_summary::Error as LatestBlockSummaryError;
 use purge_signatures::Error as PurgeSignaturesError;
+use remove_block::Error as RemoveBlockError;
 use trie_compact::Error as TrieCompactError;
 use unsparse::Error as UnsparseError;
 
@@ -34,6 +36,8 @@ pub enum Error {
     LatestBlockSummary(#[from] LatestBlockSummaryError),
     #[error("Purge signatures failed: {0}")]
     PurgeSignatures(#[from] PurgeSignaturesError),
+    #[error("Remove block failed: {0}")]
+    RemoveBlock(#[from] RemoveBlockError),
     #[error("Trie compact failed: {0}")]
     TrieCompact(#[from] TrieCompactError),
     #[error("Unsparse failed: {0}")]

--- a/src/subcommands/remove_block.rs
+++ b/src/subcommands/remove_block.rs
@@ -1,0 +1,88 @@
+mod remove;
+#[cfg(test)]
+mod tests;
+
+use std::path::Path;
+
+use bincode::Error as BincodeError;
+use casper_hashing::Digest;
+use casper_node::types::{BlockHash, DeployHash};
+use clap::{Arg, ArgMatches, Command};
+use lmdb::Error as LmdbError;
+use thiserror::Error as ThisError;
+
+pub const COMMAND_NAME: &str = "remove-block";
+const BLOCK_HASH: &str = "block-hash";
+const DB_PATH: &str = "db-path";
+
+/// Errors encountered when operating on the storage database.
+#[derive(Debug, ThisError)]
+pub enum Error {
+    /// Parsing error on entry in the block body database.
+    #[error("Error parsing block body for block with hash {0}: {1}")]
+    BodyParsing(BlockHash, BincodeError),
+    /// Database operation error.
+    #[error("Error operating the database: {0}")]
+    Database(#[from] LmdbError),
+    /// Parsing error on entry in the deploy metadata database.
+    #[error("Error parsing execution results for block with hash {0} at deploy {1}: {2}")]
+    ExecutionResultsParsing(BlockHash, DeployHash, BincodeError),
+    /// Parsing error on entry in the block header database.
+    #[error("Error parsing block header with hash {0}: {1}")]
+    HeaderParsing(BlockHash, BincodeError),
+    /// Missing entry in the deploy metadata database.
+    #[error("Deploy with hash {0} not present in the database")]
+    MissingDeploy(DeployHash),
+    /// Missing entry in the block header database.
+    #[error("Block header for block hash {0} not present in the database")]
+    MissingHeader(BlockHash),
+    /// Serialization error on entry in the deploy metadata database.
+    #[error("Error serializing execution results for deploy {0}: {1}")]
+    Serialization(DeployHash, BincodeError),
+}
+
+enum DisplayOrder {
+    DbPath,
+    BlockHash,
+}
+
+pub fn command(display_order: usize) -> Command<'static> {
+    Command::new(COMMAND_NAME)
+        .display_order(display_order)
+        .about(
+            "Removes the block header, body and execution results for a given \
+            block hash from a storage database.",
+        )
+        .arg(
+            Arg::new(DB_PATH)
+                .display_order(DisplayOrder::DbPath as usize)
+                .required(true)
+                .short('d')
+                .long(DB_PATH)
+                .takes_value(true)
+                .value_name("DB_PATH")
+                .help("Path of the directory with the `storage.lmdb` file."),
+        )
+        .arg(
+            Arg::new(BLOCK_HASH)
+                .display_order(DisplayOrder::BlockHash as usize)
+                .short('b')
+                .long(BLOCK_HASH)
+                .takes_value(true)
+                .value_name("BLOCK_HASH")
+                .help("Hash of the block to be removed."),
+        )
+}
+
+pub fn run(matches: &ArgMatches) -> Result<(), Error> {
+    let path = Path::new(matches.value_of(DB_PATH).expect("should have db-path arg"));
+    let block_hash: BlockHash = matches
+        .value_of(BLOCK_HASH)
+        .map(|block_hash_str| {
+            Digest::from_hex(block_hash_str)
+                .expect("should parse block hash to hex format")
+                .into()
+        })
+        .expect("should have block-hash arg");
+    remove::remove_block(path, block_hash)
+}

--- a/src/subcommands/remove_block/remove.rs
+++ b/src/subcommands/remove_block/remove.rs
@@ -1,0 +1,89 @@
+use std::path::Path;
+
+use casper_node::types::{BlockHash, BlockHeader, DeployMetadata};
+use lmdb::{Error as LmdbError, Transaction, WriteFlags};
+use log::warn;
+
+use crate::{
+    common::db::{
+        self, BlockBodyDatabase, BlockHeaderDatabase, Database, DeployMetadataDatabase,
+        STORAGE_FILE_NAME,
+    },
+    subcommands::execution_results_summary::block_body::BlockBody,
+};
+
+use super::Error;
+
+pub(crate) fn remove_block<P: AsRef<Path>>(db_path: P, block_hash: BlockHash) -> Result<(), Error> {
+    let storage_path = db_path.as_ref().join(STORAGE_FILE_NAME);
+    let env = db::db_env(storage_path)?;
+
+    let mut txn = env.begin_rw_txn()?;
+    let header_db = unsafe { txn.open_db(Some(BlockHeaderDatabase::db_name()))? };
+    let body_db = unsafe { txn.open_db(Some(BlockBodyDatabase::db_name()))? };
+    let deploy_metadata_db = unsafe { txn.open_db(Some(DeployMetadataDatabase::db_name()))? };
+
+    let header: BlockHeader = match txn.get(header_db, &block_hash) {
+        Ok(raw_header) => bincode::deserialize(raw_header)
+            .map_err(|bincode_err| Error::HeaderParsing(block_hash, bincode_err))?,
+        Err(LmdbError::NotFound) => {
+            return Err(Error::MissingHeader(block_hash));
+        }
+        Err(lmdb_err) => {
+            return Err(lmdb_err.into());
+        }
+    };
+
+    let maybe_body: Option<BlockBody> = match txn.get(body_db, header.body_hash()) {
+        Ok(raw_body) => Some(
+            bincode::deserialize(raw_body)
+                .map_err(|bincode_err| Error::BodyParsing(block_hash, bincode_err))?,
+        ),
+        Err(LmdbError::NotFound) => {
+            warn!(
+                "No block body found for block header with hash {}",
+                block_hash
+            );
+            None
+        }
+        Err(lmdb_err) => {
+            return Err(lmdb_err.into());
+        }
+    };
+
+    if let Some(body) = maybe_body {
+        // Go through all the deploys in this block and get the execution
+        // result of each one.
+        for deploy_hash in body.deploy_hashes() {
+            // Get this deploy's metadata.
+            let mut metadata: DeployMetadata = match txn.get(deploy_metadata_db, deploy_hash) {
+                Ok(raw_metadata) => bincode::deserialize(raw_metadata).map_err(|bincode_err| {
+                    Error::ExecutionResultsParsing(block_hash, *deploy_hash, bincode_err)
+                })?,
+                Err(LmdbError::NotFound) => return Err(Error::MissingDeploy(*deploy_hash)),
+                Err(lmdb_error) => return Err(lmdb_error.into()),
+            };
+            // Extract the execution result of this deploy for the current block.
+            if let Some(_execution_result) = metadata.execution_results.remove(&block_hash) {
+                if metadata.execution_results.is_empty() {
+                    txn.del(deploy_metadata_db, deploy_hash, None)?;
+                } else {
+                    let encoded_metadata = bincode::serialize(&metadata)
+                        .map_err(|bincode_err| Error::Serialization(*deploy_hash, bincode_err))?;
+                    txn.put(
+                        deploy_metadata_db,
+                        deploy_hash,
+                        &encoded_metadata,
+                        WriteFlags::default(),
+                    )?;
+                }
+            }
+        }
+
+        txn.del(body_db, header.body_hash(), None)?;
+    }
+
+    txn.del(header_db, &block_hash, None)?;
+    txn.commit()?;
+    Ok(())
+}

--- a/src/subcommands/remove_block/tests.rs
+++ b/src/subcommands/remove_block/tests.rs
@@ -1,0 +1,631 @@
+use std::slice;
+
+use casper_node::types::{BlockHash, DeployHash, DeployMetadata};
+use lmdb::{Error as LmdbError, Transaction, WriteFlags};
+
+use crate::{
+    common::db::{
+        BlockBodyDatabase, BlockHeaderDatabase, Database, DeployMetadataDatabase, STORAGE_FILE_NAME,
+    },
+    subcommands::{
+        execution_results_summary::block_body::BlockBody,
+        remove_block::{remove::remove_block, Error},
+    },
+    test_utils::{
+        mock_block_header, mock_deploy_hash, mock_deploy_metadata, LmdbTestFixture, MockBlockHeader,
+    },
+};
+
+#[test]
+fn remove_block_should_work() {
+    const BLOCK_COUNT: usize = 2;
+    const DEPLOY_COUNT: usize = 3;
+
+    let test_fixture = LmdbTestFixture::new(
+        vec![
+            BlockHeaderDatabase::db_name(),
+            BlockBodyDatabase::db_name(),
+            DeployMetadataDatabase::db_name(),
+        ],
+        Some(STORAGE_FILE_NAME),
+    );
+
+    let deploy_hashes: Vec<DeployHash> = (0..DEPLOY_COUNT as u8).map(mock_deploy_hash).collect();
+    let block_headers: Vec<(BlockHash, MockBlockHeader)> =
+        (0..BLOCK_COUNT as u8).map(mock_block_header).collect();
+    let mut block_bodies = vec![];
+    let mut block_body_deploy_map: Vec<Vec<usize>> = vec![];
+    block_bodies.push(BlockBody::new(vec![deploy_hashes[0], deploy_hashes[1]]));
+    block_body_deploy_map.push(vec![0, 1]);
+    block_bodies.push(BlockBody::new(vec![deploy_hashes[1], deploy_hashes[2]]));
+    block_body_deploy_map.push(vec![1, 2]);
+
+    let deploy_metadatas = vec![
+        mock_deploy_metadata(slice::from_ref(&block_headers[0].0)),
+        mock_deploy_metadata(&[block_headers[0].0, block_headers[1].0]),
+        mock_deploy_metadata(slice::from_ref(&block_headers[1].0)),
+    ];
+
+    // Insert the 2 blocks into the database.
+    {
+        let mut txn = test_fixture.env.begin_rw_txn().unwrap();
+        for i in 0..BLOCK_COUNT {
+            // Store the header.
+            txn.put(
+                *test_fixture
+                    .db(Some(BlockHeaderDatabase::db_name()))
+                    .unwrap(),
+                &block_headers[i].0,
+                &bincode::serialize(&block_headers[i].1).unwrap(),
+                WriteFlags::empty(),
+            )
+            .unwrap();
+            // Store the body.
+            txn.put(
+                *test_fixture.db(Some(BlockBodyDatabase::db_name())).unwrap(),
+                &block_headers[i].1.body_hash,
+                &bincode::serialize(&block_bodies[i]).unwrap(),
+                WriteFlags::empty(),
+            )
+            .unwrap();
+        }
+
+        // Insert the 3 deploys into the deploys and deploy_metadata databases.
+        for i in 0..DEPLOY_COUNT {
+            txn.put(
+                *test_fixture
+                    .db(Some(DeployMetadataDatabase::db_name()))
+                    .unwrap(),
+                &deploy_hashes[i],
+                &bincode::serialize(&deploy_metadatas[i]).unwrap(),
+                WriteFlags::empty(),
+            )
+            .unwrap();
+        }
+        txn.commit().unwrap();
+    };
+
+    assert!(remove_block(test_fixture.tmp_dir.path(), block_headers[0].0).is_ok());
+
+    {
+        let txn = test_fixture.env.begin_ro_txn().unwrap();
+        assert_eq!(
+            txn.get(
+                *test_fixture
+                    .db(Some(BlockHeaderDatabase::db_name()))
+                    .unwrap(),
+                &block_headers[0].0,
+            )
+            .unwrap_err(),
+            LmdbError::NotFound
+        );
+        assert!(txn
+            .get(
+                *test_fixture
+                    .db(Some(BlockHeaderDatabase::db_name()))
+                    .unwrap(),
+                &block_headers[1].0,
+            )
+            .is_ok());
+
+        assert_eq!(
+            txn.get(
+                *test_fixture.db(Some(BlockBodyDatabase::db_name())).unwrap(),
+                &block_headers[0].1.body_hash,
+            )
+            .unwrap_err(),
+            LmdbError::NotFound
+        );
+        assert!(txn
+            .get(
+                *test_fixture.db(Some(BlockBodyDatabase::db_name())).unwrap(),
+                &block_headers[1].1.body_hash,
+            )
+            .is_ok());
+
+        assert_eq!(
+            txn.get(
+                *test_fixture
+                    .db(Some(DeployMetadataDatabase::db_name()))
+                    .unwrap(),
+                &deploy_hashes[0]
+            )
+            .unwrap_err(),
+            LmdbError::NotFound
+        );
+
+        let deploy_metadata: DeployMetadata = bincode::deserialize(
+            txn.get(
+                *test_fixture
+                    .db(Some(DeployMetadataDatabase::db_name()))
+                    .unwrap(),
+                &deploy_hashes[1],
+            )
+            .unwrap(),
+        )
+        .unwrap();
+        assert!(!deploy_metadata
+            .execution_results
+            .contains_key(&block_headers[0].0));
+        assert!(deploy_metadata
+            .execution_results
+            .contains_key(&block_headers[1].0));
+
+        let deploy_metadata: DeployMetadata = bincode::deserialize(
+            txn.get(
+                *test_fixture
+                    .db(Some(DeployMetadataDatabase::db_name()))
+                    .unwrap(),
+                &deploy_hashes[2],
+            )
+            .unwrap(),
+        )
+        .unwrap();
+        assert!(!deploy_metadata
+            .execution_results
+            .contains_key(&block_headers[0].0));
+        assert!(deploy_metadata
+            .execution_results
+            .contains_key(&block_headers[1].0));
+        txn.commit().unwrap();
+    }
+}
+
+#[test]
+fn remove_block_no_deploys() {
+    const BLOCK_COUNT: usize = 2;
+    const DEPLOY_COUNT: usize = 3;
+
+    let test_fixture = LmdbTestFixture::new(
+        vec![
+            BlockHeaderDatabase::db_name(),
+            BlockBodyDatabase::db_name(),
+            DeployMetadataDatabase::db_name(),
+        ],
+        Some(STORAGE_FILE_NAME),
+    );
+
+    let deploy_hashes: Vec<DeployHash> = (0..DEPLOY_COUNT as u8).map(mock_deploy_hash).collect();
+    let block_headers: Vec<(BlockHash, MockBlockHeader)> =
+        (0..BLOCK_COUNT as u8).map(mock_block_header).collect();
+    let mut block_bodies = vec![];
+    let mut block_body_deploy_map: Vec<Vec<usize>> = vec![];
+    block_bodies.push(BlockBody::new(vec![]));
+    block_body_deploy_map.push(vec![]);
+    block_bodies.push(BlockBody::new(vec![deploy_hashes[1], deploy_hashes[2]]));
+    block_body_deploy_map.push(vec![1, 2]);
+
+    let deploy_metadatas = vec![
+        mock_deploy_metadata(&[]),
+        mock_deploy_metadata(slice::from_ref(&block_headers[1].0)),
+        mock_deploy_metadata(slice::from_ref(&block_headers[1].0)),
+    ];
+
+    // Insert the 2 blocks into the database.
+    {
+        let mut txn = test_fixture.env.begin_rw_txn().unwrap();
+        for i in 0..BLOCK_COUNT {
+            // Store the header.
+            txn.put(
+                *test_fixture
+                    .db(Some(BlockHeaderDatabase::db_name()))
+                    .unwrap(),
+                &block_headers[i].0,
+                &bincode::serialize(&block_headers[i].1).unwrap(),
+                WriteFlags::empty(),
+            )
+            .unwrap();
+            // Store the body.
+            txn.put(
+                *test_fixture.db(Some(BlockBodyDatabase::db_name())).unwrap(),
+                &block_headers[i].1.body_hash,
+                &bincode::serialize(&block_bodies[i]).unwrap(),
+                WriteFlags::empty(),
+            )
+            .unwrap();
+        }
+
+        // Insert the last 2 deploys into the deploys and deploy_metadata
+        // databases.
+        for i in 1..DEPLOY_COUNT {
+            txn.put(
+                *test_fixture
+                    .db(Some(DeployMetadataDatabase::db_name()))
+                    .unwrap(),
+                &deploy_hashes[i],
+                &bincode::serialize(&deploy_metadatas[i]).unwrap(),
+                WriteFlags::empty(),
+            )
+            .unwrap();
+        }
+        txn.commit().unwrap();
+    };
+
+    assert!(remove_block(test_fixture.tmp_dir.path(), block_headers[0].0).is_ok());
+
+    {
+        let txn = test_fixture.env.begin_ro_txn().unwrap();
+        assert_eq!(
+            txn.get(
+                *test_fixture
+                    .db(Some(BlockHeaderDatabase::db_name()))
+                    .unwrap(),
+                &block_headers[0].0,
+            )
+            .unwrap_err(),
+            LmdbError::NotFound
+        );
+        assert!(txn
+            .get(
+                *test_fixture
+                    .db(Some(BlockHeaderDatabase::db_name()))
+                    .unwrap(),
+                &block_headers[1].0,
+            )
+            .is_ok());
+
+        assert_eq!(
+            txn.get(
+                *test_fixture.db(Some(BlockBodyDatabase::db_name())).unwrap(),
+                &block_headers[0].1.body_hash,
+            )
+            .unwrap_err(),
+            LmdbError::NotFound
+        );
+        assert!(txn
+            .get(
+                *test_fixture.db(Some(BlockBodyDatabase::db_name())).unwrap(),
+                &block_headers[1].1.body_hash,
+            )
+            .is_ok());
+
+        assert_eq!(
+            txn.get(
+                *test_fixture
+                    .db(Some(DeployMetadataDatabase::db_name()))
+                    .unwrap(),
+                &deploy_hashes[0]
+            )
+            .unwrap_err(),
+            LmdbError::NotFound
+        );
+
+        let deploy_metadata: DeployMetadata = bincode::deserialize(
+            txn.get(
+                *test_fixture
+                    .db(Some(DeployMetadataDatabase::db_name()))
+                    .unwrap(),
+                &deploy_hashes[1],
+            )
+            .unwrap(),
+        )
+        .unwrap();
+        assert!(!deploy_metadata
+            .execution_results
+            .contains_key(&block_headers[0].0));
+        assert!(deploy_metadata
+            .execution_results
+            .contains_key(&block_headers[1].0));
+
+        let deploy_metadata: DeployMetadata = bincode::deserialize(
+            txn.get(
+                *test_fixture
+                    .db(Some(DeployMetadataDatabase::db_name()))
+                    .unwrap(),
+                &deploy_hashes[2],
+            )
+            .unwrap(),
+        )
+        .unwrap();
+        assert!(!deploy_metadata
+            .execution_results
+            .contains_key(&block_headers[0].0));
+        assert!(deploy_metadata
+            .execution_results
+            .contains_key(&block_headers[1].0));
+        txn.commit().unwrap();
+    }
+}
+
+#[test]
+fn remove_block_missing_header() {
+    let test_fixture = LmdbTestFixture::new(
+        vec![
+            BlockHeaderDatabase::db_name(),
+            BlockBodyDatabase::db_name(),
+            DeployMetadataDatabase::db_name(),
+        ],
+        Some(STORAGE_FILE_NAME),
+    );
+
+    let (block_hash, _block_header) = mock_block_header(0);
+    assert!(
+        matches!(remove_block(test_fixture.tmp_dir.path(), block_hash).unwrap_err(), Error::MissingHeader(actual_block_hash) if block_hash == actual_block_hash)
+    );
+}
+
+#[test]
+fn remove_block_missing_body() {
+    const BLOCK_COUNT: usize = 2;
+    const DEPLOY_COUNT: usize = 3;
+
+    let test_fixture = LmdbTestFixture::new(
+        vec![
+            BlockHeaderDatabase::db_name(),
+            BlockBodyDatabase::db_name(),
+            DeployMetadataDatabase::db_name(),
+        ],
+        Some(STORAGE_FILE_NAME),
+    );
+
+    let deploy_hashes: Vec<DeployHash> = (0..DEPLOY_COUNT as u8).map(mock_deploy_hash).collect();
+    let block_headers: Vec<(BlockHash, MockBlockHeader)> =
+        (0..BLOCK_COUNT as u8).map(mock_block_header).collect();
+    let mut block_bodies = vec![];
+    let mut block_body_deploy_map: Vec<Vec<usize>> = vec![];
+    block_bodies.push(BlockBody::new(vec![deploy_hashes[0], deploy_hashes[1]]));
+    block_body_deploy_map.push(vec![0, 1]);
+    block_bodies.push(BlockBody::new(vec![deploy_hashes[1], deploy_hashes[2]]));
+    block_body_deploy_map.push(vec![1, 2]);
+
+    let deploy_metadatas = vec![
+        mock_deploy_metadata(slice::from_ref(&block_headers[0].0)),
+        mock_deploy_metadata(&[block_headers[0].0, block_headers[1].0]),
+        mock_deploy_metadata(slice::from_ref(&block_headers[1].0)),
+    ];
+
+    // Insert the 2 block headers into the database.
+    {
+        let mut txn = test_fixture.env.begin_rw_txn().unwrap();
+        for (block_hash, block_header) in block_headers.iter().take(BLOCK_COUNT) {
+            // Store the header.
+            txn.put(
+                *test_fixture
+                    .db(Some(BlockHeaderDatabase::db_name()))
+                    .unwrap(),
+                block_hash,
+                &bincode::serialize(block_header).unwrap(),
+                WriteFlags::empty(),
+            )
+            .unwrap();
+        }
+
+        // Insert the 3 deploys into the deploys and deploy_metadata databases.
+        for i in 0..DEPLOY_COUNT {
+            txn.put(
+                *test_fixture
+                    .db(Some(DeployMetadataDatabase::db_name()))
+                    .unwrap(),
+                &deploy_hashes[i],
+                &bincode::serialize(&deploy_metadatas[i]).unwrap(),
+                WriteFlags::empty(),
+            )
+            .unwrap();
+        }
+        txn.commit().unwrap();
+    };
+
+    assert!(remove_block(test_fixture.tmp_dir.path(), block_headers[0].0).is_ok());
+
+    {
+        let txn = test_fixture.env.begin_ro_txn().unwrap();
+        assert_eq!(
+            txn.get(
+                *test_fixture
+                    .db(Some(BlockHeaderDatabase::db_name()))
+                    .unwrap(),
+                &block_headers[0].0,
+            )
+            .unwrap_err(),
+            LmdbError::NotFound
+        );
+        assert!(txn
+            .get(
+                *test_fixture
+                    .db(Some(BlockHeaderDatabase::db_name()))
+                    .unwrap(),
+                &block_headers[1].0,
+            )
+            .is_ok());
+
+        assert_eq!(
+            txn.get(
+                *test_fixture.db(Some(BlockBodyDatabase::db_name())).unwrap(),
+                &block_headers[0].1.body_hash,
+            )
+            .unwrap_err(),
+            LmdbError::NotFound
+        );
+        assert_eq!(
+            txn.get(
+                *test_fixture.db(Some(BlockBodyDatabase::db_name())).unwrap(),
+                &block_headers[1].1.body_hash,
+            )
+            .unwrap_err(),
+            LmdbError::NotFound
+        );
+        txn.commit().unwrap();
+    }
+}
+
+#[test]
+fn remove_block_missing_deploys() {
+    let test_fixture = LmdbTestFixture::new(
+        vec![
+            BlockHeaderDatabase::db_name(),
+            BlockBodyDatabase::db_name(),
+            DeployMetadataDatabase::db_name(),
+        ],
+        Some(STORAGE_FILE_NAME),
+    );
+
+    let (block_hash, block_header) = mock_block_header(0);
+    let deploy_hash = mock_deploy_hash(0);
+    let block_body = BlockBody::new(vec![deploy_hash]);
+
+    // Insert the block into the database.
+    {
+        let mut txn = test_fixture.env.begin_rw_txn().unwrap();
+
+        // Store the header.
+        txn.put(
+            *test_fixture
+                .db(Some(BlockHeaderDatabase::db_name()))
+                .unwrap(),
+            &block_hash,
+            &bincode::serialize(&block_header).unwrap(),
+            WriteFlags::empty(),
+        )
+        .unwrap();
+        // Store the body.
+        txn.put(
+            *test_fixture.db(Some(BlockBodyDatabase::db_name())).unwrap(),
+            &block_header.body_hash,
+            &bincode::serialize(&block_body).unwrap(),
+            WriteFlags::empty(),
+        )
+        .unwrap();
+
+        txn.commit().unwrap();
+    };
+
+    assert!(
+        matches!(remove_block(test_fixture.tmp_dir.path(), block_hash).unwrap_err(), Error::MissingDeploy(actual_deploy_hash) if deploy_hash == actual_deploy_hash)
+    );
+}
+
+#[test]
+fn remove_block_invalid_header() {
+    let test_fixture = LmdbTestFixture::new(
+        vec![
+            BlockHeaderDatabase::db_name(),
+            BlockBodyDatabase::db_name(),
+            DeployMetadataDatabase::db_name(),
+        ],
+        Some(STORAGE_FILE_NAME),
+    );
+
+    let (block_hash, _block_header) = mock_block_header(0);
+
+    // Insert the an invalid block header into the database.
+    {
+        let mut txn = test_fixture.env.begin_rw_txn().unwrap();
+
+        // Store the header.
+        txn.put(
+            *test_fixture
+                .db(Some(BlockHeaderDatabase::db_name()))
+                .unwrap(),
+            &block_hash,
+            &[0u8, 1u8, 2u8],
+            WriteFlags::empty(),
+        )
+        .unwrap();
+
+        txn.commit().unwrap();
+    };
+
+    assert!(
+        matches!(remove_block(test_fixture.tmp_dir.path(), block_hash).unwrap_err(), Error::HeaderParsing(actual_block_hash, _) if block_hash == actual_block_hash)
+    );
+}
+
+#[test]
+fn remove_block_invalid_body() {
+    let test_fixture = LmdbTestFixture::new(
+        vec![
+            BlockHeaderDatabase::db_name(),
+            BlockBodyDatabase::db_name(),
+            DeployMetadataDatabase::db_name(),
+        ],
+        Some(STORAGE_FILE_NAME),
+    );
+
+    let (block_hash, block_header) = mock_block_header(0);
+
+    // Insert the block header along with an invalid body into the database.
+    {
+        let mut txn = test_fixture.env.begin_rw_txn().unwrap();
+
+        // Store the header.
+        txn.put(
+            *test_fixture
+                .db(Some(BlockHeaderDatabase::db_name()))
+                .unwrap(),
+            &block_hash,
+            &bincode::serialize(&block_header).unwrap(),
+            WriteFlags::empty(),
+        )
+        .unwrap();
+        // Store the body.
+        txn.put(
+            *test_fixture.db(Some(BlockBodyDatabase::db_name())).unwrap(),
+            &block_header.body_hash,
+            &[0u8, 1u8, 2u8],
+            WriteFlags::empty(),
+        )
+        .unwrap();
+
+        txn.commit().unwrap();
+    };
+
+    assert!(
+        matches!(remove_block(test_fixture.tmp_dir.path(), block_hash).unwrap_err(), Error::BodyParsing(actual_block_hash, _) if block_hash == actual_block_hash)
+    );
+}
+
+#[test]
+fn remove_block_invalid_deploy_metadata() {
+    let test_fixture = LmdbTestFixture::new(
+        vec![
+            BlockHeaderDatabase::db_name(),
+            BlockBodyDatabase::db_name(),
+            DeployMetadataDatabase::db_name(),
+        ],
+        Some(STORAGE_FILE_NAME),
+    );
+
+    let (block_hash, block_header) = mock_block_header(0);
+    let deploy_hash = mock_deploy_hash(0);
+    let block_body = BlockBody::new(vec![deploy_hash]);
+
+    // Insert the block into the database.
+    {
+        let mut txn = test_fixture.env.begin_rw_txn().unwrap();
+
+        // Store the header.
+        txn.put(
+            *test_fixture
+                .db(Some(BlockHeaderDatabase::db_name()))
+                .unwrap(),
+            &block_hash,
+            &bincode::serialize(&block_header).unwrap(),
+            WriteFlags::empty(),
+        )
+        .unwrap();
+        // Store the body.
+        txn.put(
+            *test_fixture.db(Some(BlockBodyDatabase::db_name())).unwrap(),
+            &block_header.body_hash,
+            &bincode::serialize(&block_body).unwrap(),
+            WriteFlags::empty(),
+        )
+        .unwrap();
+        // Store the deploy metadata.
+        txn.put(
+            *test_fixture
+                .db(Some(DeployMetadataDatabase::db_name()))
+                .unwrap(),
+            &deploy_hash,
+            &[0u8, 1u8, 2u8],
+            WriteFlags::empty(),
+        )
+        .unwrap();
+
+        txn.commit().unwrap();
+    };
+
+    assert!(
+        matches!(remove_block(test_fixture.tmp_dir.path(), block_hash).unwrap_err(), Error::ExecutionResultsParsing(actual_block_hash, actual_deploy_hash, _) if block_hash == actual_block_hash && deploy_hash == actual_deploy_hash)
+    );
+}


### PR DESCRIPTION
Fixes #36 

This PR adds the `remove-block` subcommand. It takes a path to a storage file and a block hash for which to remove the header, body and execution results of that block.